### PR TITLE
Process_Folder: enhance check for directory path

### DIFF
--- a/src/main/resources/templates/Macros/Process_Folder.ijm
+++ b/src/main/resources/templates/Macros/Process_Folder.ijm
@@ -15,7 +15,7 @@ processFolder(input);
 function processFolder(input) {
 	list = getFileList(input);
 	for (i = 0; i < list.length; i++) {
-		if(endsWith(list[i], "/"))
+		if(File.isDirectory(list[i]))
 			processFolder("" + input + list[i]);
 		if(endsWith(list[i], suffix))
 			processFile(input, output, list[i]);


### PR DESCRIPTION
Michael Schmid suggested on the ImageJ mailing list that it's better to use File.isDirectory(path) instead of endsWith(path, "/").
See http://imagej.1557.x6.nabble.com/Recursive-processing-of-a-directory-not-working-correctly-tp5007797p5007819.html
