### PR TITLE
Add Plugin annotation to ChooseTabSize command

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/commands/ChooseTabSize.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/ChooseTabSize.java
@@ -31,9 +31,11 @@
 
 package org.scijava.ui.swing.script.commands;
 
+import org.scijava.command.Command;
 import org.scijava.command.DynamicCommand;
 import org.scijava.module.MutableModuleItem;
 import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
 import org.scijava.ui.swing.script.TextEditor;
 
 /**
@@ -41,6 +43,7 @@ import org.scijava.ui.swing.script.TextEditor;
  *
  * @author Johannes Schindelin
  */
+@Plugin(type=Command.class)
 public class ChooseTabSize extends DynamicCommand {
 
 	@Parameter


### PR DESCRIPTION
Without this change, this `Command` cannot be auto-discovered by the `CommandService`.

Fixes https://github.com/scijava/script-editor/issues/9.

I discovered this while looking for example uses of `DynamicCommand`, see also [this discussion on the forum](http://forum.imagej.net/t/scijava-batch-processor/5548?u=imagejan).
