### PR TITLE
Adjust fonts of the screen and error window when adjusting the editor's font

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>script-editor</artifactId>
-	<version>0.3.2-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 
 	<name>SciJava Script Editor</name>
 	<description>Script Editor and Interpreter for SciJava script languages.</description>

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -305,8 +305,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 				@Override
 				public void actionPerformed(final ActionEvent event) {
-					getEditorPane().setFontSize(size);
-					updateTabAndFontSize(false);
+					setFontSize(size);
 				}
 			});
 			for (final char c : ("" + size).toCharArray()) {
@@ -1204,7 +1203,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		else if (source == increaseFontSize || source == decreaseFontSize) {
 			getEditorPane().increaseFontSize(
 				(float) (source == increaseFontSize ? 1.2 : 1 / 1.2));
-			updateTabAndFontSize(false);
+			setFontSize(getEditorPane().getFontSize());
 		}
 		else if (source == nextTab) switchTabRelative(1);
 		else if (source == previousTab) switchTabRelative(-1);
@@ -2454,4 +2453,15 @@ public class TextEditor extends JFrame implements ActionListener,
 		setTitle();
 	}
 
+	public void setFontSize(final float size) {
+		if (getEditorPane().getFontSize() != size)
+			getEditorPane().setFontSize(size);
+		changeFontSize(errorScreen, size);
+		changeFontSize(getTab().screen, size);
+		updateTabAndFontSize(false);
+	}
+
+	private void changeFontSize(final JTextArea a, final float size) {
+		a.setFont(a.getFont().deriveFont(size));
+	}
 }

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -217,6 +217,10 @@ public class TextEditorTab extends JSplitPane {
 		return showingErrors ? textEditor.getErrorScreen() : screen;
 	}
 
+	public JTextArea getScreenInstance() {
+		return screen;
+	}
+
 	boolean isExecuting() {
 		return null != getExecuter();
 	}

--- a/src/main/java/org/scijava/ui/swing/script/commands/ChooseFontSize.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/ChooseFontSize.java
@@ -31,6 +31,8 @@
 
 package org.scijava.ui.swing.script.commands;
 
+import javax.swing.JTextArea;
+
 import org.scijava.command.ContextCommand;
 import org.scijava.plugin.Parameter;
 import org.scijava.ui.swing.script.TextEditor;
@@ -51,7 +53,14 @@ public class ChooseFontSize extends ContextCommand {
 	@Override
 	public void run() {
 		editor.getEditorPane().setFontSize(fontSize);
+		final float size = editor.getEditorPane().getFontSize();
+		changeFontSize(editor.getErrorScreen(), size);
+		changeFontSize(editor.getTab().getScreenInstance(), size);
 		editor.updateTabAndFontSize(false);
+	}
+
+	private void changeFontSize(final JTextArea a, final float size) {
+		a.setFont(a.getFont().deriveFont(size));
 	}
 
 	protected void initializeChoice() {


### PR DESCRIPTION
Until this commit, the font of the screen (the lower part) was not adjusted when adjusting the font of the editor pane (the upper part). With this commit, it does.