### PR TITLE
A REPL for the Script Editor and incremental evaluation

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -2485,7 +2485,10 @@ public class TextEditor extends JFrame implements ActionListener,
 					if (KeyEvent.VK_ENTER == keyCode) {
 						if (0 != ke.getModifiers()) return;
 						final String text = prompt.getText();
-						if (null == text || 0 == text.trim().length()) return;
+						if (null == text || 0 == text.trim().length()) {
+							ke.consume(); // avoid writing the line break
+							return;
+						}
 						if ('\\' == text.charAt(text.length() -1)) {
 							// Allow writing the line break when the last character is a backslash
 							return;

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -40,11 +40,12 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -90,6 +91,7 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
 import javax.swing.KeyStroke;
@@ -1965,7 +1967,25 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	/** Invoke in the context of the event dispatch thread. */
 	private void execute(final boolean selectionOnly) throws IOException {
+		final String text;
 		final TextEditorTab tab = getTab();
+		if (selectionOnly) {
+			final String selected = tab.getEditorPane().getSelectedText();
+			if (selected == null) {
+				error("Selection required!");
+				text = null;
+			}
+			else text = selected + "\n"; // Ensure code blocks are terminated
+		}
+		else {
+			text = tab.getEditorPane().getText();
+		}
+		
+		execute(tab, text);
+	}
+	
+	/** Invoke in the context of the event dispatch thread. */
+	private void execute(final TextEditorTab tab, final String text) throws IOException {
 
 		tab.prepare();
 
@@ -2009,18 +2029,6 @@ public class TextEditor extends JFrame implements ActionListener,
 		// Write into PipedOutputStream
 		// from another Thread
 		try {
-			final String text;
-			if (selectionOnly) {
-				final String selected = tab.getEditorPane().getSelectedText();
-				if (selected == null) {
-					error("Selection required!");
-					text = null;
-				}
-				else text = selected + "\n"; // Ensure code blocks are terminated
-			}
-			else {
-				text = tab.getEditorPane().getText();
-			}
 			new Thread() {
 
 				{
@@ -2116,15 +2124,21 @@ public class TextEditor extends JFrame implements ActionListener,
 		textArea.insert(text, length);
 		textArea.setCaretPosition(length);
 	}
-
+	
 	public void markCompileStart() {
+		markCompileStart(true);
+	}
+
+	public void markCompileStart(final boolean with_timestamp) {
 		errorHandler = null;
 
-		final String started =
-			"Started " + getEditorPane().getFileName() + " at " + new Date() + "\n";
+		if (with_timestamp) {
+			final String started =
+					"Started " + getEditorPane().getFileName() + " at " + new Date() + "\n";
+			append(errorScreen, started);
+			append(getTab().screen, started);
+		}
 		final int offset = errorScreen.getDocument().getLength();
-		append(errorScreen, started);
-		append(getTab().screen, started);
 		compileStartOffset = errorScreen.getDocument().getLength();
 		try {
 			compileStartPosition = errorScreen.getDocument().createPosition(offset);
@@ -2449,6 +2463,52 @@ public class TextEditor extends JFrame implements ActionListener,
 	
 	public void setIncremental(final boolean incremental) {
 		this.incremental = incremental;
+		
+		final JTextArea prompt = this.getTab().getPrompt();
+		if (incremental) {
+			getTab().getScreenAndPromptSplit().setDividerLocation(0.5);
+			prompt.addKeyListener(new KeyAdapter() {
+				private final ArrayList<String> commands = new ArrayList<String>();
+				private int index = -1;
+				@Override
+				public void keyPressed(final KeyEvent ke) {
+					final int keyCode = ke.getKeyCode();
+					if (KeyEvent.VK_ENTER == keyCode) {
+						if (0 != ke.getModifiers()) return;
+						final String text = prompt.getText();
+						if (null == text || "" == text.trim()) return;
+						if ('\\' == text.charAt(text.length() -1)) {
+							// Allow writing the line break when the last character is a backslash
+							return;
+						}
+						commands.add(text);
+						index = commands.size() - 1;
+						try {
+							getTab().getScreen().append(">" + text + "\n");
+							markCompileStart(false); // weird method name, execute will call markCompileEnd
+							execute(getTab(), text);
+						} catch (Throwable t) {
+							log.error(t);
+						}
+						ke.consume(); // avoid writing the line break
+					} else if (KeyEvent.VK_PAGE_UP == keyCode) {
+						if (index > 0) prompt.setText(commands.get(--index));
+						ke.consume();
+					} else if (KeyEvent.VK_PAGE_DOWN == keyCode) {
+						if (index < commands.size() -1) prompt.setText(commands.get(++index));
+						else prompt.setText("");
+						ke.consume();
+					}
+				}
+			});
+		} else {
+			prompt.setText(""); // clear
+			prompt.setEnabled(false);
+			for (final KeyListener kl : prompt.getKeyListeners()) {
+				prompt.removeKeyListener(kl);
+			}
+			getTab().getScreenAndPromptSplit().setDividerLocation(0.0);
+		}
 	}
 
 	private String adjustPath(final String path, final String langName) {

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -2491,13 +2491,15 @@ public class TextEditor extends JFrame implements ActionListener,
 							return;
 						}
 						try {
+							final JTextArea screen = getTab().screen;
 							getTab().showOutput();
-							getTab().screen.append("> " + text + "\n");
+							screen.append("> " + text + "\n");
 							commands.add(text);
 							index = commands.size() - 1;
 							markCompileStart(false); // weird method name, execute will call markCompileEnd
 							execute(getTab(), text);
 							prompt.setText("");
+							screen.scrollRectToVisible(screen.modelToView(screen.getDocument().getLength()));
 						} catch (Throwable t) {
 							log.error(t);
 						}

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -2375,7 +2375,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		context.inject(module);
 
 		// use the currently selected language to execute the script
-		module.setLanguage(language);
+		info.setLanguage(language);
 
 		// map stdout and stderr to the UI
 		module.setOutputWriter(output);

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -44,6 +44,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.FileInputStream;
@@ -225,6 +226,10 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	private Map<ScriptLanguage, JRadioButtonMenuItem> languageMenuItems;
 	private JRadioButtonMenuItem noneLanguageItem;
+	
+	private EditableScriptInfo scriptInfo;
+	private ScriptModule module;
+	private boolean incremental = false;
 
 	public TextEditor(final Context context) {
 		super("Script Editor");
@@ -1601,6 +1606,9 @@ public class TextEditor extends JFrame implements ActionListener,
 	}
 
 	void setLanguage(final ScriptLanguage language, final boolean addHeader) {
+		if (null != this.getCurrentLanguage() && this.getCurrentLanguage().getLanguageName() != language.getLanguageName()) {
+			this.scriptInfo = null;
+		}
 		getEditorPane().setLanguage(language, addHeader);
 
 		setTitle();
@@ -2359,27 +2367,72 @@ public class TextEditor extends JFrame implements ActionListener,
 		if (language == null) return false;
 		return language.isCompiledLanguage();
 	}
+	
+	private final class EditableScriptInfo extends ScriptInfo
+	{	
+		private String script;
+		
+		public EditableScriptInfo(final Context context, final String path, final Reader reader) {
+			super(context, path, reader);
+		}
+		
+		public void setScript(final Reader reader) throws IOException {
+			final char[] buffer = new char[8192];
+			final StringBuilder builder = new StringBuilder();
+
+			int read;
+			while ((read = reader.read(buffer)) != -1) {
+				builder.append(buffer, 0, read);
+			}
+
+			this.script = builder.toString();
+		}
+		
+		@Override
+		public String getProcessedScript() {
+			return null == this.script ? super.getProcessedScript() : this.script;
+		}
+	}
 
 	private Reader evalScript(final String filename, Reader reader,
 		final Writer output, final Writer errors) throws ModuleException
 	{
 		final ScriptLanguage language = getCurrentLanguage();
-		if (respectAutoImports) {
-			reader =
-				DefaultAutoImporters.prefixAutoImports(context, language, reader,
-					errors);
+		
+		// If there's no engine or the language has changed or the language is compiled from a file
+		// then create the engine and module anew
+		if (!this.incremental
+			|| (this.incremental && null == this.scriptInfo)
+		    || language.isCompiledLanguage()
+		    || (null != this.scriptInfo
+		        && this.scriptInfo.getLanguage().getLanguageName()
+		           != getCurrentLanguage().getLanguageName()))
+		{
+			if (respectAutoImports) {
+				reader =
+						DefaultAutoImporters.prefixAutoImports(context, language, reader,
+								errors);
+			}
+			// create script module for execution
+			this.scriptInfo = new EditableScriptInfo(context, filename, reader);
+
+			// use the currently selected language to execute the script
+			this.scriptInfo.setLanguage(language);
+			
+			this.module = this.scriptInfo.createModule();
+			context.inject(this.module);
+		} else {
+			try {
+				// Same engine, with persistent state
+				this.scriptInfo.setScript( reader );
+			} catch (IOException e) {
+				log.error(e);
+			}
 		}
-		// create script module for execution
-		final ScriptInfo info = new ScriptInfo(context, filename, reader);
-		final ScriptModule module = info.createModule();
-		context.inject(module);
-
-		// use the currently selected language to execute the script
-		info.setLanguage(language);
-
+		
 		// map stdout and stderr to the UI
-		module.setOutputWriter(output);
-		module.setErrorWriter(errors);
+		this.module.setOutputWriter(output);
+		this.module.setErrorWriter(errors);
 
 		// execute the script
 		try {
@@ -2392,6 +2445,10 @@ public class TextEditor extends JFrame implements ActionListener,
 			log.error(e);
 		}
 		return reader;
+	}
+	
+	public void setIncremental(final boolean incremental) {
+		this.incremental = incremental;
 	}
 
 	private String adjustPath(final String path, final String langName) {

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -665,6 +665,8 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		final EditorPane editorPane = getEditorPane();
 		editorPane.requestFocus();
+		
+		getTab().getScreenAndPromptSplit().setDividerLocation(1.0);
 	}
 
 	public LogService log() { return log; }
@@ -2522,7 +2524,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			for (final KeyListener kl : prompt.getKeyListeners()) {
 				prompt.removeKeyListener(kl);
 			}
-			getTab().getScreenAndPromptSplit().setDividerLocation(0.0);
+			getTab().getScreenAndPromptSplit().setDividerLocation(1.0);
 		}
 	}
 

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -39,6 +39,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
@@ -62,6 +63,7 @@ public class TextEditorTab extends JSplitPane {
 	protected boolean showingErrors;
 	private Executer executer;
 	private final JButton runit, batchit, killit, toggleErrors;
+	private final JCheckBox incremental;
 
 	private final TextEditor textEditor;
 
@@ -118,13 +120,25 @@ public class TextEditorTab extends JSplitPane {
 			}
 		});
 		bottom.add(killit, bc);
-
+		
 		bc.gridx = 3;
+		incremental = new JCheckBox("persistent");
+		incremental.setEnabled(true);
+		incremental.setSelected(false);
+		incremental.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(final ActionEvent ae) {
+				textEditor.setIncremental(incremental.isSelected());
+			}
+		});
+		bottom.add(incremental, bc);
+
+		bc.gridx = 4;
 		bc.fill = GridBagConstraints.HORIZONTAL;
 		bc.weightx = 1;
 		bottom.add(new JPanel(), bc);
 
-		bc.gridx = 4;
+		bc.gridx = 5;
 		bc.fill = GridBagConstraints.NONE;
 		bc.weightx = 0;
 		bc.anchor = GridBagConstraints.NORTHEAST;
@@ -138,7 +152,7 @@ public class TextEditorTab extends JSplitPane {
 		});
 		bottom.add(toggleErrors, bc);
 
-		bc.gridx = 5;
+		bc.gridx = 6;
 		bc.fill = GridBagConstraints.NONE;
 		bc.weightx = 0;
 		bc.anchor = GridBagConstraints.NORTHEAST;
@@ -158,7 +172,7 @@ public class TextEditorTab extends JSplitPane {
 		bc.fill = GridBagConstraints.BOTH;
 		bc.weightx = 1;
 		bc.weighty = 1;
-		bc.gridwidth = 6;
+		bc.gridwidth = 7;
 		screen.setEditable(false);
 		screen.setLineWrap(true);
 		final Font font = new Font("Courier", Font.PLAIN, 12);

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -53,6 +53,7 @@ import org.scijava.ui.swing.script.TextEditor.Executer;
  *
  * @author Jonathan Hale
  */
+@SuppressWarnings("serial")
 public class TextEditorTab extends JSplitPane {
 
 	protected final EditorPane editorPane;

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -59,11 +59,13 @@ public class TextEditorTab extends JSplitPane {
 
 	protected final EditorPane editorPane;
 	protected final JTextArea screen = new JTextArea();
+	protected final JTextArea prompt = new JTextArea();
 	protected final JScrollPane scroll;
 	protected boolean showingErrors;
 	private Executer executer;
 	private final JButton runit, batchit, killit, toggleErrors;
 	private final JCheckBox incremental;
+	private final JSplitPane screenAndPromptSplit;
 
 	private final TextEditor textEditor;
 
@@ -129,6 +131,7 @@ public class TextEditorTab extends JSplitPane {
 			@Override
 			public void actionPerformed(final ActionEvent ae) {
 				textEditor.setIncremental(incremental.isSelected());
+				prompt.setEnabled(incremental.isSelected());
 			}
 		});
 		bottom.add(incremental, bc);
@@ -180,9 +183,19 @@ public class TextEditorTab extends JSplitPane {
 		scroll = new JScrollPane(screen);
 		scroll.setPreferredSize(new Dimension(600, 80));
 		bottom.add(scroll, bc);
-
+		
+		prompt.setEnabled(false);
+		
+		screenAndPromptSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, prompt, bottom);
+		screenAndPromptSplit.setDividerLocation(0.0); // prompt collapsed by default
+		
 		super.setTopComponent(editorPane.wrappedInScrollbars());
-		super.setBottomComponent(bottom);
+		super.setBottomComponent(screenAndPromptSplit);
+	}
+	
+	// Package-private
+	JSplitPane getScreenAndPromptSplit() {
+		return screenAndPromptSplit;
 	}
 
 	/** Invoke in the context of the event dispatch thread. */
@@ -230,6 +243,10 @@ public class TextEditorTab extends JSplitPane {
 
 	public JTextArea getScreen() {
 		return showingErrors ? textEditor.getErrorScreen() : screen;
+	}
+	
+	public JTextArea getPrompt() {
+		return prompt;
 	}
 
 	boolean isExecuting() {

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -40,6 +40,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
@@ -70,7 +71,7 @@ public class TextEditorTab extends JSplitPane {
 	private final TextEditor textEditor;
 
 	public TextEditorTab(final TextEditor textEditor) {
-		super(JSplitPane.VERTICAL_SPLIT);
+		super(JSplitPane.HORIZONTAL_SPLIT);
 		super.setResizeWeight(350.0 / 430.0);
 
 		this.textEditor = textEditor;
@@ -130,6 +131,11 @@ public class TextEditorTab extends JSplitPane {
 		incremental.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(final ActionEvent ae) {
+				if (incremental.isSelected() && null == textEditor.getCurrentLanguage()) {
+					incremental.setSelected(false);
+					JOptionPane.showMessageDialog(TextEditorTab.this, "Select a language first!");
+					return;
+				}
 				textEditor.setIncremental(incremental.isSelected());
 				prompt.setEnabled(incremental.isSelected());
 			}
@@ -181,16 +187,17 @@ public class TextEditorTab extends JSplitPane {
 		final Font font = new Font("Courier", Font.PLAIN, 12);
 		screen.setFont(font);
 		scroll = new JScrollPane(screen);
-		scroll.setPreferredSize(new Dimension(600, 80));
+		scroll.setPreferredSize(new Dimension(400, 600));
 		bottom.add(scroll, bc);
 		
 		prompt.setEnabled(false);
 		
-		screenAndPromptSplit = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, prompt, bottom);
-		screenAndPromptSplit.setDividerLocation(0.0); // prompt collapsed by default
+		screenAndPromptSplit = new JSplitPane(JSplitPane.VERTICAL_SPLIT, bottom, prompt);
 		
-		super.setTopComponent(editorPane.wrappedInScrollbars());
-		super.setBottomComponent(screenAndPromptSplit);
+		super.setLeftComponent(editorPane.wrappedInScrollbars());
+		super.setRightComponent(screenAndPromptSplit);
+		screenAndPromptSplit.setDividerLocation(600);
+		screenAndPromptSplit.setDividerLocation(1.0);
 	}
 	
 	// Package-private


### PR DESCRIPTION
These commits bring an optional REPL for the Script Editor. To activate it, tick the "incremental" checkbox.

When "incremental" is ticked:
1. The underlying ScriptEngine is persisted. Therefore, additional runs of the script--the whole, or some selected text--will run against the context of all prior evaluations. This is similar to how e.g. emacs allows incremental evaluation of common lisp.
2. The prompt is enabled, and shown. Text typed in the prompt will be evaluated upon pushing VK_ENTER. Code executed from the prompt will run within the same persisted ScriptEngine.

The goal is to be able to run e.g. scripts that load images and perform some operations, but then fail at some point, and then be able to:
1. inspect the successfully executed parts of the script in the prompt;
2. correct the error and rerun only the yet-to-be-evaluated parts of the script, avoiding having to e.g. reload images or other costly operations.
3. interact with the result of the script from the prompt.

To reset the ScriptEngine, deselect the checkbox and select it again. A new ScriptEngine will be created, resetting any persisted state.

A very desirable side effect is that now all the script interpreters from the fiji-legacy package become finally obsolete. The new Script interpreter is also superseded.

The java language is not supported in incremental mode. Only languages that aren't compiled from written files will be able to run in incremental mode.

Needs abundant testing, particularly by parties that use different scripting languages.