### PR TITLE
FileSystemTree: run UI updates in the event dispatch thread

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
@@ -507,10 +507,14 @@ public class FileSystemTree extends JTree
 					if (null != node) nodes.add(node);
 				}
 
-				for (final Node node : nodes) {
-					node.updateChildrenList(FileSystemTree.this.getModel());
-					FileSystemTree.this.expandPath(new TreePath(node.getPath()));
-				}
+				SwingUtilities.invokeLater(new Runnable() {
+					public void run() {
+						for (final Node node : nodes) {
+							node.updateChildrenList(FileSystemTree.this.getModel());
+							FileSystemTree.this.expandPath(new TreePath(node.getPath()));
+						}
+					}
+				});
 
 				boolean valid = key.reset();
 				if (!valid) {


### PR DESCRIPTION
rather than in the file system watcher thread.

This fixes the whole Fiji UI lock ups I've been seeing randomly in association with e.g. saving a file in the Script Editor whose parent folder is listed in the FileSystemTree.