### PR TITLE
Upgrade to miglayout-swing-5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,8 @@ Genetics, and others.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
+		<miglayout-swing.version>5.2</miglayout-swing.version>
 	</properties>
 
 	<repositories>
@@ -179,8 +181,8 @@ Genetics, and others.</license.copyrightOwners>
 		</dependency>
 		<dependency>
 			<groupId>com.miglayout</groupId>
-			<artifactId>miglayout</artifactId>
-			<classifier>swing</classifier>
+			<artifactId>miglayout-swing</artifactId>
+			<version>${miglayout-swing.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
@@ -202,6 +204,12 @@ Genetics, and others.</license.copyrightOwners>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-swing</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>


### PR DESCRIPTION
This requires temporary exclusion of the incompatible dependency in `scijava-ui-swing`.

* The exclusion can be removed once https://github.com/scijava/scijava-ui-swing/pull/46 is merged and released.
* The version pinning can be removed once we have a `pom-scijava` release managing this version (see https://github.com/scijava/pom-scijava/pull/97).