### PR TITLE
FileSystemTree event loop: ignore children file events that aren't CREATE or DELETE.

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
@@ -572,7 +572,8 @@ public class FileSystemTree extends JTree
 
 				for (final WatchEvent<?> event: key.pollEvents()) {
 					final WatchEvent.Kind<?> kind = event.kind();
-					if (StandardWatchEventKinds.OVERFLOW == kind) {
+					if (StandardWatchEventKinds.OVERFLOW == kind
+					 || StandardWatchEventKinds.ENTRY_MODIFY == kind) { // ignore e.g. files getting larger or smaller
 						continue;
 					}
 


### PR DESCRIPTION
Before, if a file in a folder shown in Fiji's Script Editor file tree was modified (e.g. grew in size), the whole subtree of the folder would be recreated, which is an expensive UI operation, and an entirely unnecessary one.

Issue spotted by @haesleinhuepf at https://forum.image.sc/t/fiji-hangs-because-of-specific-folders-in-the-side-bar-of-the-script-editor/36582