### PR TITLE
bugfix: put tokenmakers in hashmap with the correct name

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -935,7 +935,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		for (final PluginInfo<SyntaxHighlighter> info : pluginService
 			.getPluginsOfType(SyntaxHighlighter.class))
 			try {
-				tokenMakerFactory.putMapping("text/" + info.getName(), info
+				tokenMakerFactory.putMapping("text/" + info.getName().toLowerCase().replace(' ', '-'), info
 					.getClassName());
 			}
 			catch (final Throwable t) {


### PR DESCRIPTION
Hi all,

I just found that bug which is related to naming of TokenMakers. Assume you have a new scripting language, e.g. called "Te Oki" which comes with a TokenMaker marked as SciJava plugin having the name "Te Oki". It will be put in the hashmap of the token maker factory with key "text/Te Oki" [link](https://github.com/scijava/script-editor/blob/master/src/main/java/org/scijava/ui/swing/script/TextEditor.java#L938)

Later, when the user selectes that scipting language, the editor searches for a map entry named "text/te-oki" but not "text/Te Oki". [link](https://github.com/scijava/script-editor/blob/master/src/main/java/org/scijava/ui/swing/script/EditorPane.java#L497)

I assume there is some kind of standard that these map entries shouldn't have spaces or upper case characters. Thus, I'm suggesting this bugfix.

Let me know if I can help with anything.

Cheers,
Robert