### PR TITLE
Fix open help with new menu item "Source or javadoc for class or package..."

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/ClassUtil.java
+++ b/src/main/java/org/scijava/ui/swing/script/ClassUtil.java
@@ -121,9 +121,9 @@ public class ClassUtil {
 					String scijava_javadoc_url = scijava_javadoc_URLs.get(props.name.toLowerCase());
 					if (null == scijava_javadoc_url) {
 						// Try cropping name at the first whitespace if any (e.g. "ImgLib2 Core Library" to "ImgLib2")
-						final int ispace = props.name.indexOf(' ');
-						if (-1 != ispace) {
-							scijava_javadoc_url = scijava_javadoc_URLs.get(props.name.toLowerCase().substring(0, ispace));
+						for (final String word: props.name.split(" ")) {
+							scijava_javadoc_url = scijava_javadoc_URLs.get(word.toLowerCase());
+							if (null != scijava_javadoc_url) break; // found a valid one
 						}
 					}
 					if (null != scijava_javadoc_url) {

--- a/src/main/java/org/scijava/ui/swing/script/ClassUtil.java
+++ b/src/main/java/org/scijava/ui/swing/script/ClassUtil.java
@@ -1,0 +1,233 @@
+package org.scijava.ui.swing.script;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ClassUtil {
+	
+	static private final String scijava_javadoc_URL = "https://javadoc.scijava.org/"; // with ending slash
+	
+	/** Cache of class names vs list of URLs found in the pom.xml files of their contaning jar files, if any. */
+	static private final Map<String, JarProperties> class_urls = new HashMap<>();
+	
+	/** Cache of subURL javadoc at https://javadoc.scijava.org */
+	static private final HashMap<String, String> scijava_javadoc_URLs = new HashMap<>();
+	
+	static private final void ensureCache() {
+		synchronized (class_urls) {
+			if (class_urls.isEmpty())
+				class_urls.putAll(findAllClasses());
+		}
+	}
+	
+	static public final void ensureSciJavaSubURLCache() {
+		synchronized (scijava_javadoc_URLs) {
+			if (!scijava_javadoc_URLs.isEmpty()) return;
+			Scanner scanner = null;
+			try {
+				final Pattern pattern = Pattern.compile("<div class=\"jdbox\"><div><a href=\"(.*?)\">");
+				final URLConnection connection =  new URL(scijava_javadoc_URL).openConnection();
+				scanner = new Scanner(connection.getInputStream());
+				while (scanner.hasNext()) {
+					final Matcher matcher = pattern.matcher(scanner.nextLine());
+					if (matcher.find()) {
+						String name = matcher.group(1).toLowerCase();
+						if (name.endsWith("/")) name = name.substring(0, name.length() -1);
+						scijava_javadoc_URLs.put(name, scijava_javadoc_URL + matcher.group(1));
+					}
+				}
+				scanner.close();
+			} catch ( Exception e ) {
+				e.printStackTrace();
+			} finally {
+				if (null != scanner) scanner.close();
+			}
+		}
+	}
+	
+	static public HashMap<String, JarProperties> findClassDocumentationURLs(final String s) {
+		ensureCache();
+		final HashMap<String, JarProperties> matches = new HashMap<>();
+		for (final Map.Entry<String, JarProperties> entry: class_urls.entrySet()) {
+			if (entry.getKey().contains(s)) {
+				final JarProperties props = entry.getValue();
+				matches.put(entry.getKey(), new JarProperties(props.name, new ArrayList<String>(props.urls)));
+			}
+		}
+		return matches;
+	}
+	
+	static public HashMap<String, ArrayList<String>> findDocumentationForClass(final String s) {
+		final HashMap<String, JarProperties> matches = findClassDocumentationURLs(s);
+		ensureSciJavaSubURLCache();
+		
+		final Pattern java8 = Pattern.compile("^(java|javax|org.omg|org.w3c|org.xml|org.ietf.jgss)\\..*$");
+		
+		final HashMap<String, ArrayList<String>> class_urls = new HashMap<>();
+		
+		for (final Map.Entry<String, JarProperties> entry: matches.entrySet()) {
+			final String classname = entry.getKey();
+			final ArrayList<String> urls = new ArrayList<>();
+			class_urls.put(classname, urls);
+			if (java8.matcher(classname).matches()) {
+				urls.add(scijava_javadoc_URLs.get("java8") + classname.replace('.', '/') + ".html");
+			} else {
+				final JarProperties props = entry.getValue();
+				// Find the first URL with git in it
+				for (final String url : props.urls) {
+					final boolean github = url.contains("/github.com"),
+								  gitlab = url.contains("/gitlab.com");
+					if (github || gitlab) {
+						// Find the 5th slash, e.g. https://github.com/imglib/imglib2/
+						int count = 0;
+						int last = 0;
+						while (count < 5) {
+							last = url.indexOf('/', last + 1);
+							if (-1 == last) break; // less than 5 found
+							++count;
+						}
+						String urlbase = url;
+						if (5 == count) urlbase = url.substring(0, last); // without the ending slash
+						// Assume maven, since these URLs were found in a pom.xml: src/main/java/
+						urls.add(urlbase + (gitlab ? "/-" : "") + "/blob/master/src/main/java/" + classname.replace('.', '/') + ".java");
+						break;
+					}
+				}
+				// Try to find a javadoc in the scijava website
+				if (null != props.name) {
+					String scijava_javadoc_url = scijava_javadoc_URLs.get(props.name.toLowerCase());
+					if (null == scijava_javadoc_url) {
+						// Try cropping name at the first whitespace if any (e.g. "ImgLib2 Core Library" to "ImgLib2")
+						final int ispace = props.name.indexOf(' ');
+						if (-1 != ispace) {
+							scijava_javadoc_url = scijava_javadoc_URLs.get(props.name.toLowerCase().substring(0, ispace));
+						}
+					}
+					if (null != scijava_javadoc_url) {
+						urls.add(scijava_javadoc_url + classname.replace('.', '/') + ".html");
+					} else {
+						// Try Fiji: could be a plugin
+						Scanner scanner = null;
+						try {
+							final String url = scijava_javadoc_URL + "Fiji/" + classname.replace('.', '/') + ".html";
+							final URLConnection c = new URL(url).openConnection();
+							scanner = new Scanner(c.getInputStream());
+							while (scanner.hasNext()) {
+								final String line = scanner.nextLine();
+								if (line.contains("<title>")) {
+									if (!line.contains("<title>404")) {
+										urls.add(url);
+									}
+									break;
+								}
+							}
+						} catch (Exception e) {
+							// Ignore: 404 that wasn't redirected to an error page
+						} finally {
+							if (null != scanner) scanner.close();
+						}
+					}
+				}
+			}
+		}
+
+		return class_urls;
+	}
+	
+	static public final class JarProperties {
+		public final ArrayList<String> urls;
+		public String name = null;
+		public JarProperties(final String name, final ArrayList<String> urls) {
+			this.name = name;
+			this.urls = urls;
+		}
+	}
+	
+	static public final HashMap<String, JarProperties> findAllClasses() {
+		// Find all jar files
+		final ArrayList<String> jarFilePaths = new ArrayList<String>();
+		final LinkedList<String> dirs = new LinkedList<>();
+		dirs.add(System.getProperty("java.home"));
+		dirs.add(System.getProperty("ij.dir"));
+		final HashSet<String> seenDirs = new HashSet<>();
+		while (!dirs.isEmpty()) {
+			final String filepath = dirs.removeFirst();
+			final File file = new File(filepath);
+			seenDirs.add(file.getAbsolutePath());
+			if (file.exists()) {
+				if (file.isDirectory()) {
+					for (final File child : file.listFiles()) {
+						final String childfilepath = child.getAbsolutePath();
+						if (seenDirs.contains(childfilepath)) continue;
+						if (child.isDirectory()) dirs.add(childfilepath);
+						else if (childfilepath.endsWith(".jar")) jarFilePaths.add(childfilepath);
+					}
+				}
+			}
+		}
+		// Find all classes from all jar files
+		final HashMap<String, JarProperties> class_urls = new HashMap<>();
+		final Pattern urlpattern = Pattern.compile(">(http.*?)<");
+		final Pattern namepattern = Pattern.compile("<name>(.*?)<");
+		for (final String jarpath : jarFilePaths) {
+			JarFile jar = null;
+			try {
+				jar = new JarFile(jarpath);
+				final Enumeration<JarEntry> entries = jar.entries();
+				final ArrayList<String> urls = new ArrayList<>();
+				final JarProperties props = new JarProperties(null, urls);
+				// For every filepath in the jar zip archive
+				while (entries.hasMoreElements()) {
+					final JarEntry entry = entries.nextElement();
+					if (entry.isDirectory()) continue;
+					if (entry.getName().endsWith(".class")) {
+						String classname = entry.getName().replace('/', '.');
+						final int idollar = classname.indexOf('$');
+						if (-1 != idollar) {
+							classname = classname.substring(0, idollar); // truncate at the first dollar sign
+						} else {
+							classname = classname.substring(0, classname.length() - 6); // without .class
+						}
+						class_urls.put(classname, props);
+					} else if (entry.getName().endsWith("/pom.xml")) {
+						final Scanner scanner = new Scanner(jar.getInputStream(entry));
+						while (scanner.hasNext()) {
+							final String line = scanner.nextLine();
+							final Matcher matcher1 = urlpattern.matcher(line);
+							if (matcher1.find()) {
+								urls.add(matcher1.group(1));
+							}
+							if (null == props.name) {
+								final Matcher matcher2 = namepattern.matcher(line);
+								if (matcher2.find()) {
+									props.name = matcher2.group(1);
+								}
+							}
+						}
+						scanner.close();
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			} finally {
+				if (null != jar) try {
+					jar.close();
+				} catch (IOException e) { e.printStackTrace(); }
+			}
+		}
+		return class_urls;
+	}
+}

--- a/src/main/java/org/scijava/ui/swing/script/ClassUtil.java
+++ b/src/main/java/org/scijava/ui/swing/script/ClassUtil.java
@@ -74,16 +74,21 @@ public class ClassUtil {
 		final HashMap<String, JarProperties> matches = findClassDocumentationURLs(s);
 		ensureSciJavaSubURLCache();
 		
-		final Pattern java8 = Pattern.compile("^(java|javax|org.omg|org.w3c|org.xml|org.ietf.jgss)\\..*$");
-		
+		final Pattern javaPackages = Pattern.compile("^(java|javax|org\\.omg|org\\.w3c|org\\.xml|org\\.ietf\\.jgss)\\..*$");
+		final String version = System.getProperty("java.version");
+		final String majorVersion = version.startsWith("1.") ?
+				  version.substring(2, version.indexOf('.', 2))
+				: version.substring(0, version.indexOf('.'));
+		final String javaDoc = "java" + majorVersion;
+	
 		final HashMap<String, ArrayList<String>> class_urls = new HashMap<>();
 		
 		for (final Map.Entry<String, JarProperties> entry: matches.entrySet()) {
 			final String classname = entry.getKey();
 			final ArrayList<String> urls = new ArrayList<>();
 			class_urls.put(classname, urls);
-			if (java8.matcher(classname).matches()) {
-				urls.add(scijava_javadoc_URLs.get("java8") + classname.replace('.', '/') + ".html");
+			if (javaPackages.matcher(classname).matches()) {
+				urls.add(scijava_javadoc_URLs.get(javaDoc) + classname.replace('.', '/') + ".html");
 			} else {
 				final JarProperties props = entry.getValue();
 				// Find the first URL with git in it

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -988,7 +988,12 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		final int windowWidth = prefService.getInt(getClass(), WINDOW_WIDTH, dim.width);
 		final int windowHeight = prefService.getInt(getClass(), WINDOW_HEIGHT, dim.height);
-		setPreferredSize(new Dimension(windowWidth, windowHeight));
+		// Avoid creating a window larger than the desktop
+		final Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();
+		if (windowWidth > screen.getWidth() || windowHeight > screen.getHeight())
+			setPreferredSize(new Dimension(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT));
+		else
+			setPreferredSize(new Dimension(windowWidth, windowHeight));
 
 		final int mainDivLocation = prefService.getInt(getClass(), MAIN_DIV_LOCATION, body.getDividerLocation());
 		body.setDividerLocation(mainDivLocation);

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -2712,10 +2712,18 @@ public class TextEditor extends JFrame implements ActionListener,
 				final JLabel class_label = new JLabel(classname);
 				gridbag.setConstraints(class_label, c);
 				panel.add(class_label);
-				for (final String url: matches.get(classname)) {
+				ArrayList<String> urls = matches.get(classname);
+				if (urls.isEmpty()) {
+					urls = new ArrayList<String>();
+					urls.add("https://duckduckgo.com/?q=" + classname);
+				}
+				for (final String url: urls) {
 					c.gridx += 1;
 					c.anchor = GridBagConstraints.WEST;
-					final JButton link = new JButton(url.endsWith("java") ? "Source" : "JavaDoc");
+					String title = "JavaDoc";
+					if (url.endsWith(".java")) title = "Source";
+					else if (url.contains("duckduckgo")) title = "Search...";
+					final JButton link = new JButton(title);
 					gridbag.setConstraints(link, c);
 					panel.add(link);
 					link.addActionListener(new ActionListener() {


### PR DESCRIPTION
Create new menu item "Source or javadoc for class or package..." which fixes or replaces the "Open Help" menu item, by using ClassUtils and showing a UI that lists all matching classes with buttons to open their source code in github or gitlab and the javadoc when available (will guess the URL, load it, and not show a link to it when 404).

Can match partial text (the list of possible classes may be longer) and can also match package names or partial package names. Any substring of a fully qualified class name will be matched, which is fabulous.

(Compare with current implementation of "Open Help..." which requires a fully qualified class name to work, which is not useful as often one does not know it or not have it handy in a script.)