### PR TITLE
GUI improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>script-editor</artifactId>
-	<version>0.6.2-SNAPSHOT</version>
+	<version>0.7.0-SNAPSHOT</version>
 
 	<name>SciJava Script Editor</name>
 	<description>Script Editor and Interpreter for SciJava script languages.</description>

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -546,7 +546,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	public boolean isAutoCompletionEnabled() {
-		return autoCompletionWithoutKey;
+		return autoCompletionEnabled;
 	}
 
 	public boolean isKeylessAutoCompletionEnabled() {
@@ -747,7 +747,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	public static final String TABLINES_VISIBLE_PREFS = "script.editor.Tablines";
 	public static final String THEME_PREFS = "script.editor.theme";
 	public static final String AUTOCOMPLETE_PREFS = "script.editor.AC";
-	public static final String AUTOCOMPLETE_NOKEY_PREFS = "script.editor.ACNoKey";
+	public static final String AUTOCOMPLETE_KEYLESS_PREFS = "script.editor.ACNoKey";
 	public static final String AUTOCOMPLETE_FALLBACK_PREFS = "script.editor.ACFallback";
 	public static final String MARK_OCCURRENCES_PREFS = "script.editor.Occurrences";
 	public static final String FOLDERS_PREFS = "script.editor.folders";
@@ -766,7 +766,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			setTabsEmulated(false);
 			setPaintTabLines(false);
 			setAutoCompletion(true);
-			setKeylessAutoCompletion(false);
+			setKeylessAutoCompletion(true); // true for backwards compatibility with IJ1 macro auto-completion
 			setFallbackAutoCompletion(false);
 			setMarkOccurrences(false);
 		} else {
@@ -777,7 +777,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			setWhitespaceVisible(prefService.getBoolean(getClass(), WHITESPACE_VISIBLE_PREFS, isWhitespaceVisible()));
 			setPaintTabLines(prefService.getBoolean(getClass(), TABLINES_VISIBLE_PREFS, getPaintTabLines()));
 			setAutoCompletion(prefService.getBoolean(getClass(), AUTOCOMPLETE_PREFS, true));
-			setKeylessAutoCompletion(prefService.getBoolean(getClass(), AUTOCOMPLETE_NOKEY_PREFS, false));
+			setKeylessAutoCompletion(prefService.getBoolean(getClass(), AUTOCOMPLETE_KEYLESS_PREFS, true)); // true for backwards compatibility with IJ1 macro
 			setFallbackAutoCompletion(prefService.getBoolean(getClass(), AUTOCOMPLETE_FALLBACK_PREFS, false));
 			setMarkOccurrences(prefService.getBoolean(getClass(), MARK_OCCURRENCES_PREFS, false));
 		}
@@ -802,7 +802,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		prefService.put(getClass(), WHITESPACE_VISIBLE_PREFS, isWhitespaceVisible());
 		prefService.put(getClass(), TABLINES_VISIBLE_PREFS, getPaintTabLines());
 		prefService.put(getClass(), AUTOCOMPLETE_PREFS, isAutoCompletionEnabled());
-		prefService.put(getClass(), AUTOCOMPLETE_NOKEY_PREFS, isKeylessAutoCompletionEnabled());
+		prefService.put(getClass(), AUTOCOMPLETE_KEYLESS_PREFS, isKeylessAutoCompletionEnabled());
 		prefService.put(getClass(), AUTOCOMPLETE_FALLBACK_PREFS, isFallbackAutoCompletionEnabled());
 		if (null != top_folders) prefService.put(getClass(), FOLDERS_PREFS, top_folders);
 		if (null != theme) prefService.put(getClass(), THEME_PREFS, theme);

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -737,6 +737,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	public static final String THEME_PREFS = "script.editor.theme";
 	public static final String AUTOCOMPLETE_PREFS = "script.editor.Autocomp";
 	public static final String AUTOCOMPLETE_NOKEY_PREFS = "script.editor.AutocompKey";
+	public static final String MARK_OCCURRENCES_PREFS = "script.editor.Occurrences";
 	public static final String FOLDERS_PREFS = "script.editor.folders";
 	public static final int DEFAULT_TAB_SIZE = 4;
 	public static final String DEFAULT_THEME = "default";
@@ -754,6 +755,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			setPaintTabLines(false);
 			setAutoCompletionEnabled(true);
 			setAutoCompletionNoKeyRequired(false);
+			setMarkOccurrences(false);
 		} else {
 			resetTabSize();
 			setFontSize(prefService.getFloat(getClass(), FONT_SIZE_PREFS, getFontSize()));
@@ -763,6 +765,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			setPaintTabLines(prefService.getBoolean(getClass(), TABLINES_VISIBLE_PREFS, getPaintTabLines()));
 			setAutoCompletionEnabled(prefService.getBoolean(getClass(), AUTOCOMPLETE_PREFS, true));
 			setAutoCompletionNoKeyRequired(prefService.getBoolean(getClass(), AUTOCOMPLETE_NOKEY_PREFS, false));
+			setMarkOccurrences(prefService.getBoolean(getClass(), MARK_OCCURRENCES_PREFS, false));
 		}
 	}
 

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -93,7 +93,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 
 	private boolean undoInProgress;
 	private boolean redoInProgress;
-	private boolean autoCompletionEnabled = true;
+	private boolean autoCompletionEnabled;
 	private boolean autoCompletionJavaFallback;
 	private boolean autoCompletionWithoutKey;
 
@@ -123,6 +123,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		setCloseMarkupTags(true);
 		setCodeFoldingEnabled(true);
 		setShowMatchedBracketPopup(true);
+		setClearWhitespaceLinesEnabled(false); // most folks wont't want this set?
 
 		// load preferences
 		loadPreferences();
@@ -532,28 +533,51 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			support.install(this);
 	}
 
-	public void setAutoCompletion(boolean value) {
-		autoCompletionEnabled = value;
-		if (currentLanguage != null) setLanguage(currentLanguage);
+	/**
+	 * Toggles whether auto-completion is enabled.
+	 * 
+	 * @param enabled Whether auto-activation is enabled.
+	 */
+	public void setAutoCompletion(final boolean enabled) {
+		autoCompletionEnabled = enabled;
+		if (currentLanguage != null)
+			setLanguage(currentLanguage);
 	}
 
-	void setFallbackAutoCompletion(boolean value) {
+	/**
+	 * Toggles whether auto-completion should adopt Java completions if the current
+	 * language does not support auto-completion.
+	 * 
+	 * @param enabled Whether Java should be enabled as fallback language for
+	 *                auto-completion
+	 */
+	void setFallbackAutoCompletion(final boolean value) {
 		autoCompletionJavaFallback = value;
+		if (autoCompletionEnabled && currentLanguage != null)
+			setLanguage(currentLanguage);
 	}
 
-	void setKeylessAutoCompletion(boolean value) {
-		autoCompletionWithoutKey = value;
+	/**
+	 * Toggles whether auto-activation of auto-completion is enabled. Ignored if
+	 * auto-completion is not enabled.
+	 *
+	 * @param enabled Whether auto-activation is enabled.
+	 */
+	void setKeylessAutoCompletion(final boolean enabled) {
+		autoCompletionWithoutKey = enabled;
+		if (autoCompletionEnabled && currentLanguage != null)
+			setLanguage(currentLanguage);
 	}
 
 	public boolean isAutoCompletionEnabled() {
 		return autoCompletionEnabled;
 	}
 
-	public boolean isKeylessAutoCompletionEnabled() {
+	public boolean isAutoCompletionKeyless() {
 		return autoCompletionWithoutKey;
 	}
 
-	public boolean isFallbackAutoCompletionEnabled() {
+	public boolean isAutoCompletionFallbackEnabled() {
 		return autoCompletionJavaFallback;
 	}
 
@@ -802,8 +826,8 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		prefService.put(getClass(), WHITESPACE_VISIBLE_PREFS, isWhitespaceVisible());
 		prefService.put(getClass(), TABLINES_VISIBLE_PREFS, getPaintTabLines());
 		prefService.put(getClass(), AUTOCOMPLETE_PREFS, isAutoCompletionEnabled());
-		prefService.put(getClass(), AUTOCOMPLETE_KEYLESS_PREFS, isKeylessAutoCompletionEnabled());
-		prefService.put(getClass(), AUTOCOMPLETE_FALLBACK_PREFS, isFallbackAutoCompletionEnabled());
+		prefService.put(getClass(), AUTOCOMPLETE_KEYLESS_PREFS, isAutoCompletionKeyless());
+		prefService.put(getClass(), AUTOCOMPLETE_FALLBACK_PREFS, isAutoCompletionFallbackEnabled());
 		if (null != top_folders) prefService.put(getClass(), FOLDERS_PREFS, top_folders);
 		if (null != theme) prefService.put(getClass(), THEME_PREFS, theme);
 	}

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -523,6 +523,14 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		setLanguage(currentLanguage);
 	}
 
+	private boolean autoCompletionKeyRequired = false;
+	void setAutoCompletionKeyRequired(boolean value) {
+		autoCompletionKeyRequired = value;
+	}
+	public boolean getAutoCompletionKeyRequired() {
+		return autoCompletionKeyRequired;
+	}
+
 	/**
 	 * Get file currently open in this {@link EditorPane}.
 	 *

--- a/src/main/java/org/scijava/ui/swing/script/FileDrop.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileDrop.java
@@ -1,0 +1,992 @@
+/*
+ * #%L
+ * Script Editor and Interpreter for SciJava script languages.
+ * %%
+ * Copyright (C) 2009 - 2022 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ui.swing.script;
+
+import java.awt.datatransfer.DataFlavor;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Reader;
+
+import javax.swing.UIManager;
+
+
+/**
+ * This class makes it easy to drag and drop files from the operating system to
+ * a Java program. Any <tt>java.awt.Component</tt> can be dropped onto, but only
+ * <tt>javax.swing.JComponent</tt>s will indicate the drop event with a changed
+ * border.
+ * <p>
+ * To use this class, construct a new <tt>FileDrop</tt> by passing it the target
+ * component and a <tt>Listener</tt> to receive notification when file(s) have
+ * been dropped. Here is an example:
+ * </p>
+ * 
+ * <pre>
+ *      JPanel myPanel = new JPanel();
+ *      new FileDrop( myPanel, new FileDrop.Listener()
+ *      {   public void filesDropped( java.io.File[] files )
+ *          {   
+ *              // handle file drop
+ *              ...
+ *          }   // end filesDropped
+ *      }); // end FileDrop.Listener
+ * </pre>
+ * <p>
+ * You can specify the border that will appear when files are being dragged by
+ * calling the constructor with a <tt>javax.swing.border.Border</tt>. Only
+ * <tt>JComponent</tt>s will show any indication with a border.
+ * </p>
+ * <p>
+ * You can turn on some debugging features by passing a <tt>PrintStream</tt>
+ * object (such as <tt>System.out</tt>) into the full constructor. A
+ * <tt>null</tt> value will result in no extra debugging information being
+ * output.
+ * </p>
+ *
+ * <p>
+ * I'm releasing this code into the Public Domain. Enjoy.
+ * </p>
+ * <p>
+ * Original author: Robert Harder, rob@iharder.net
+ * </p>
+ * <p>
+ * Additional support:
+ * </p>
+ * <ul>
+ * <li>September 2007, Nathan Blomquist -- Linux (KDE/Gnome) support added.</li>
+ * <li>December 2010, Joshua Gerth</li>
+ * <li>June 2019, TF, Adjust defaultBorderColor. Code cleanup. Added the ability
+ * to abort drop operation using Esc
+ * </ul>
+ *
+ * @author Robert Harder
+ * @version 1.1.1
+ */
+public class FileDrop {
+	private transient javax.swing.border.Border normalBorder;
+	private transient java.awt.dnd.DropTargetListener dropListener;
+
+	/** Discover if the running JVM is modern enough to have drag and drop. */
+	private static Boolean supportsDnD;
+
+	// Default border color
+	private static java.awt.Color defaultBorderColor = UIManager.getColor("Tree.selectionBackground");
+	static {
+		if (defaultBorderColor == null) defaultBorderColor = new java.awt.Color(0f,0f, 1f, 0.25f);
+	}
+
+	/**
+	 * Constructs a {@link FileDrop} with a default light-blue border and, if
+	 * <var>c</var> is a {@link java.awt.Container}, recursively sets all
+	 * elements contained within as drop targets, though only the top level
+	 * container will change borders.
+	 *
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	public FileDrop(final java.awt.Component c, final Listener listener) {
+		this(null, // Logging stream
+				c, // Drop target
+				javax.swing.BorderFactory.createMatteBorder(2, 2, 2, 2,
+						defaultBorderColor), // Drag border
+				true, // Recursive
+				listener);
+	} // end constructor
+
+	/**
+	 * Constructor with a default border and the option to recursively set drop
+	 * targets. If your component is a <tt>java.awt.Container</tt>, then each of
+	 * its children components will also listen for drops, though only the
+	 * parent will change borders.
+	 *
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param recursive
+	 *            Recursively set children as drop targets.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	protected FileDrop(final java.awt.Component c, final boolean recursive,
+			final Listener listener) {
+		this(null, // Logging stream
+				c, // Drop target
+				javax.swing.BorderFactory.createMatteBorder(2, 2, 2, 2,
+						defaultBorderColor), // Drag border
+				recursive, // Recursive
+				listener);
+	} // end constructor
+
+	/**
+	 * Constructor with a default border and debugging optionally turned on.
+	 * With Debugging turned on, more status messages will be displayed to
+	 * <tt>out</tt>. A common way to use this constructor is with
+	 * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for the
+	 * parameter <tt>out</tt> will result in no debugging output.
+	 *
+	 * @param out
+	 *            PrintStream to record debugging info or null for no debugging.
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	protected FileDrop(final java.io.PrintStream out, final java.awt.Component c,
+			final Listener listener) {
+		this(out, // Logging stream
+				c, // Drop target
+				javax.swing.BorderFactory.createMatteBorder(2, 2, 2, 2,
+						defaultBorderColor), false, // Recursive
+				listener);
+	} // end constructor
+
+	/**
+	 * Constructor with a default border, debugging optionally turned on and the
+	 * option to recursively set drop targets. If your component is a
+	 * <tt>java.awt.Container</tt>, then each of its children components will
+	 * also listen for drops, though only the parent will change borders. With
+	 * Debugging turned on, more status messages will be displayed to
+	 * <tt>out</tt>. A common way to use this constructor is with
+	 * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for the
+	 * parameter <tt>out</tt> will result in no debugging output.
+	 *
+	 * @param out
+	 *            PrintStream to record debugging info or null for no debugging.
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param recursive
+	 *            Recursively set children as drop targets.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	protected FileDrop(final java.io.PrintStream out, final java.awt.Component c,
+			final boolean recursive, final Listener listener) {
+		this(out, // Logging stream
+				c, // Drop target
+				javax.swing.BorderFactory.createMatteBorder(2, 2, 2, 2,
+						defaultBorderColor), // Drag border
+				recursive, // Recursive
+				listener);
+	} // end constructor
+
+	/**
+	 * Constructor with a specified border
+	 *
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param dragBorder
+	 *            Border to use on <tt>JComponent</tt> when dragging occurs.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	protected FileDrop(final java.awt.Component c,
+			final javax.swing.border.Border dragBorder, final Listener listener) {
+		this(null, // Logging stream
+				c, // Drop target
+				dragBorder, // Drag border
+				false, // Recursive
+				listener);
+	} // end constructor
+
+	/**
+	 * Constructor with a specified border and the option to recursively set
+	 * drop targets. If your component is a <tt>java.awt.Container</tt>, then
+	 * each of its children components will also listen for drops, though only
+	 * the parent will change borders.
+	 *
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param dragBorder
+	 *            Border to use on <tt>JComponent</tt> when dragging occurs.
+	 * @param recursive
+	 *            Recursively set children as drop targets.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	protected FileDrop(final java.awt.Component c,
+			final javax.swing.border.Border dragBorder,
+			final boolean recursive, final Listener listener) {
+		this(null, c, dragBorder, recursive, listener);
+	} // end constructor
+
+	/**
+	 * Constructor with a specified border and debugging optionally turned on.
+	 * With Debugging turned on, more status messages will be displayed to
+	 * <tt>out</tt>. A common way to use this constructor is with
+	 * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for the
+	 * parameter <tt>out</tt> will result in no debugging output.
+	 *
+	 * @param out
+	 *            PrintStream to record debugging info or null for no debugging.
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param dragBorder
+	 *            Border to use on <tt>JComponent</tt> when dragging occurs.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	protected FileDrop(final java.io.PrintStream out, final java.awt.Component c,
+			final javax.swing.border.Border dragBorder, final Listener listener) {
+		this(out, // Logging stream
+				c, // Drop target
+				dragBorder, // Drag border
+				false, // Recursive
+				listener);
+	} // end constructor
+
+	/**
+	 * Full constructor with a specified border and debugging optionally turned
+	 * on. With Debugging turned on, more status messages will be displayed to
+	 * <tt>out</tt>. A common way to use this constructor is with
+	 * <tt>System.out</tt> or <tt>System.err</tt>. A <tt>null</tt> value for the
+	 * parameter <tt>out</tt> will result in no debugging output.
+	 *
+	 * @param out
+	 *            PrintStream to record debugging info or null for no debugging.
+	 * @param c
+	 *            Component on which files will be dropped.
+	 * @param dragBorder
+	 *            Border to use on <tt>JComponent</tt> when dragging occurs.
+	 * @param recursive
+	 *            Recursively set children as drop targets.
+	 * @param listener
+	 *            Listens for <tt>filesDropped</tt>.
+	 * @since 1.0
+	 */
+	protected FileDrop(final java.io.PrintStream out, final java.awt.Component c,
+			final javax.swing.border.Border dragBorder,
+			final boolean recursive, final Listener listener) {
+
+		if (supportsDnD()) { // Make a drop listener
+			dropListener = new java.awt.dnd.DropTargetListener() {
+				@Override
+				public void dragEnter(final java.awt.dnd.DropTargetDragEvent evt) {
+					log(out, "FileDrop: dragEnter event.");
+
+					// Is this an acceptable drag event?
+					if (isDragOk(out, evt) && c.isEnabled()) {
+						// If it's a Swing component, set its border
+						if (c instanceof javax.swing.JComponent) {
+							final javax.swing.JComponent jc = (javax.swing.JComponent) c;
+							if (normalBorder == null) {
+								normalBorder = jc.getBorder();
+							} // end if: border not yet saved
+							log(out, "FileDrop: normal border saved.");
+							jc.setBorder(dragBorder);
+							log(out, "FileDrop: drag border set.");
+						} // end if: JComponent
+
+						// Acknowledge that it's okay to enter
+						// evt.acceptDrag(
+						// java.awt.dnd.DnDConstants.ACTION_COPY_OR_MOVE );
+						evt.acceptDrag(java.awt.dnd.DnDConstants.ACTION_COPY);
+						log(out, "FileDrop: event accepted.");
+					} // end if: drag ok
+					else { // Reject the drag event
+						evt.rejectDrag();
+						log(out, "FileDrop: event rejected.");
+					} // end else: drag not ok
+				} // end dragEnter
+
+				@Override
+				public void dragOver(final java.awt.dnd.DropTargetDragEvent evt) { // This
+																				// is
+																				// called
+																				// continually
+																				// as
+																				// long
+																				// as
+																				// the
+																				// mouse
+																				// is
+																				// over
+																				// the
+																				// drag
+																				// target.
+				} // end dragOver
+
+				@Override
+				public void drop(final java.awt.dnd.DropTargetDropEvent evt) {
+					log(out, "FileDrop: drop event.");
+					try { // Get whatever was dropped
+						final java.awt.datatransfer.Transferable tr = evt
+								.getTransferable();
+
+						// Is it a file list?
+						if (tr.isDataFlavorSupported(java.awt.datatransfer.DataFlavor.javaFileListFlavor)) {
+							// Say we'll take it.
+							// evt.acceptDrop (
+							// java.awt.dnd.DnDConstants.ACTION_COPY_OR_MOVE );
+							evt.acceptDrop(java.awt.dnd.DnDConstants.ACTION_COPY);
+							log(out, "FileDrop: file list accepted.");
+
+							// Get a useful list
+							final java.util.List<?> fileList = (java.util.List<?>) tr
+									.getTransferData(java.awt.datatransfer.DataFlavor.javaFileListFlavor);
+							//final java.util.Iterator<?> iterator = fileList.iterator();
+
+							// Convert list to array
+							final java.io.File[] filesTemp = new java.io.File[fileList
+									.size()];
+							fileList.toArray(filesTemp);
+							final java.io.File[] files = filesTemp;
+
+							// Alert listener to drop.
+							if (listener != null)
+								listener.filesDropped(files);
+
+							// Mark that drop is completed.
+							evt.getDropTargetContext().dropComplete(true);
+							log(out, "FileDrop: drop complete.");
+						} // end if: file list
+						else // this section will check for a reader flavor.
+						{
+							// Thanks, Nathan!
+							// BEGIN 2007-09-12 Nathan Blomquist -- Linux
+							// (KDE/Gnome) support added.
+							final DataFlavor[] flavors = tr.getTransferDataFlavors();
+							boolean handled = false;
+							for (int zz = 0; zz < flavors.length; zz++) {
+								if (flavors[zz].isRepresentationClassReader()) {
+									// Say we'll take it.
+									// evt.acceptDrop (
+									// java.awt.dnd.DnDConstants.ACTION_COPY_OR_MOVE
+									// );
+									evt.acceptDrop(java.awt.dnd.DnDConstants.ACTION_COPY);
+									log(out, "FileDrop: reader accepted.");
+
+									final Reader reader = flavors[zz]
+											.getReaderForText(tr);
+
+									final BufferedReader br = new BufferedReader(
+											reader);
+
+									if (listener != null)
+										listener.filesDropped(createFileArray(
+												br, out));
+
+									// Mark that drop is completed.
+									evt.getDropTargetContext().dropComplete(
+											true);
+									log(out, "FileDrop: drop complete.");
+									handled = true;
+									break;
+								}
+							}
+							if (!handled) {
+								log(out,
+										"FileDrop: not a file list or reader - abort.");
+								evt.rejectDrop();
+							}
+							// END 2007-09-12 Nathan Blomquist -- Linux
+							// (KDE/Gnome) support added.
+						} // end else: not a file list
+					} // end try
+					catch (final java.io.IOException io) {
+						log(out, "FileDrop: IOException - abort:");
+						io.printStackTrace(out);
+						evt.rejectDrop();
+					} // end catch IOException
+					catch (final java.awt.datatransfer.UnsupportedFlavorException ufe) {
+						log(out,
+								"FileDrop: UnsupportedFlavorException - abort:");
+						ufe.printStackTrace(out);
+						evt.rejectDrop();
+					} // end catch: UnsupportedFlavorException
+					finally {
+						// If it's a Swing component, reset its border
+						if (c instanceof javax.swing.JComponent) {
+							final javax.swing.JComponent jc = (javax.swing.JComponent) c;
+							jc.setBorder(normalBorder);
+							log(out, "FileDrop: normal border restored.");
+						} // end if: JComponent
+					} // end finally
+				} // end drop
+
+				@Override
+				public void dragExit(final java.awt.dnd.DropTargetEvent evt) {
+					log(out, "FileDrop: dragExit event.");
+					// If it's a Swing component, reset its border
+					if (c instanceof javax.swing.JComponent) {
+						final javax.swing.JComponent jc = (javax.swing.JComponent) c;
+						jc.setBorder(normalBorder);
+						log(out, "FileDrop: normal border restored.");
+					} // end if: JComponent
+				} // end dragExit
+
+				@Override
+				public void dropActionChanged(
+						final java.awt.dnd.DropTargetDragEvent evt) {
+					log(out, "FileDrop: dropActionChanged event.");
+					// Is this an acceptable drag event?
+					if (isDragOk(out, evt)) { // evt.acceptDrag(
+												// java.awt.dnd.DnDConstants.ACTION_COPY_OR_MOVE
+												// );
+						evt.acceptDrag(java.awt.dnd.DnDConstants.ACTION_COPY);
+						log(out, "FileDrop: event accepted.");
+					} // end if: drag ok
+					else {
+						evt.rejectDrag();
+						log(out, "FileDrop: event rejected.");
+					} // end else: drag not ok
+				} // end dropActionChanged
+			}; // end DropTargetListener
+
+			// Make the component (and possibly children) drop targets
+			makeDropTarget(out, c, recursive);
+		} // end if: supports dnd
+		else {
+			log(out, "FileDrop: Drag and drop is not supported with this JVM");
+		} // end else: does not support DnD
+	} // end constructor
+
+	private static boolean supportsDnD() { // Static Boolean
+		if (supportsDnD == null) {
+			boolean support = false;
+			try {
+				Class.forName("java.awt.dnd.DnDConstants");
+				support = true;
+			} // end try
+			catch (final Exception e) {
+				support = false;
+			} // end catch
+			supportsDnD = Boolean.valueOf(support);
+		} // end if: first time through
+		return supportsDnD.booleanValue();
+	} // end supportsDnD
+
+	// BEGIN 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
+	private static String ZERO_CHAR_STRING = "" + (char) 0;
+
+	private static File[] createFileArray(final BufferedReader bReader,
+			final PrintStream out) {
+		try {
+			final java.util.List<File> list = new java.util.ArrayList<File>();
+			java.lang.String line = null;
+			while ((line = bReader.readLine()) != null) {
+				try {
+					// kde seems to append a 0 char to the end of the reader
+					if (ZERO_CHAR_STRING.equals(line))
+						continue;
+
+					final java.io.File file = new java.io.File(new java.net.URI(line));
+					list.add(file);
+				} catch (final Exception ex) {
+					log(out, "Error with " + line + ": " + ex.getMessage());
+				}
+			}
+
+			return list.toArray(new File[list.size()]);
+		} catch (final IOException ex) {
+			log(out, "FileDrop: IOException");
+		}
+		return new File[0];
+	}
+
+	// END 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support added.
+
+	private void makeDropTarget(final java.io.PrintStream out,
+			final java.awt.Component c, final boolean recursive) {
+		// Make drop target
+		final java.awt.dnd.DropTarget dt = new java.awt.dnd.DropTarget();
+		try {
+			dt.addDropTargetListener(dropListener);
+		} // end try
+		catch (final java.util.TooManyListenersException e) {
+			e.printStackTrace();
+			log(out,
+					"FileDrop: Drop will not work due to previous error. Do you have another listener attached?");
+		} // end catch
+
+		// Listen for hierarchy changes and remove the drop target when the
+		// parent gets cleared out.
+		c.addHierarchyListener(new java.awt.event.HierarchyListener() {
+			@Override
+			public void hierarchyChanged(final java.awt.event.HierarchyEvent evt) {
+				log(out, "FileDrop: Hierarchy changed.");
+				final java.awt.Component parent = c.getParent();
+				if (parent == null) {
+					c.setDropTarget(null);
+					log(out, "FileDrop: Drop target cleared from component.");
+				} // end if: null parent
+				else {
+					new java.awt.dnd.DropTarget(c, dropListener);
+					log(out, "FileDrop: Drop target added to component.");
+				} // end else: parent not null
+			} // end hierarchyChanged
+		}); // end hierarchy listener
+		if (c.getParent() != null)
+			new java.awt.dnd.DropTarget(c, dropListener);
+
+		if (recursive && (c instanceof java.awt.Container)) {
+			// Get the container
+			final java.awt.Container cont = (java.awt.Container) c;
+
+			// Get it's components
+			final java.awt.Component[] comps = cont.getComponents();
+
+			// Set it's components as listeners also
+			for (int i = 0; i < comps.length; i++)
+				makeDropTarget(out, comps[i], recursive);
+		} // end if: recursively set components as listener
+	} // end dropListener
+
+	/** Determine if the dragged data is a file list. */
+	private boolean isDragOk(final java.io.PrintStream out,
+			final java.awt.dnd.DropTargetDragEvent evt) {
+		boolean ok = false;
+
+		// Get data flavors being dragged
+		final java.awt.datatransfer.DataFlavor[] flavors = evt
+				.getCurrentDataFlavors();
+
+		// See if any of the flavors are a file list
+		int i = 0;
+		while (!ok && i < flavors.length) {
+			// BEGIN 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support
+			// added.
+			// Is the flavor a file list?
+			final DataFlavor curFlavor = flavors[i];
+			if (curFlavor
+					.equals(java.awt.datatransfer.DataFlavor.javaFileListFlavor)
+					|| curFlavor.isRepresentationClassReader()) {
+				ok = true;
+			}
+			// END 2007-09-12 Nathan Blomquist -- Linux (KDE/Gnome) support
+			// added.
+			i++;
+		} // end while: through flavors
+
+		// If logging is enabled, show data flavors
+		if (out != null) {
+			if (flavors.length == 0)
+				log(out, "FileDrop: no data flavors.");
+			for (i = 0; i < flavors.length; i++)
+				log(out, flavors[i].toString());
+		} // end if: logging enabled
+
+		return ok;
+	} // end isDragOk
+
+	/** Outputs <tt>message</tt> to <tt>out</tt> if it's not null. */
+	private static void log(final java.io.PrintStream out, final String message) { // Log
+																		// message
+																		// if
+																		// requested
+		if (out != null)
+			out.println(message);
+	} // end log
+
+	/**
+	 * Removes the drag-and-drop hooks from the component and optionally from
+	 * the all children. You should call this if you add and remove components
+	 * after you've set up the drag-and-drop. This will recursively unregister
+	 * all components contained within <var>c</var> if <var>c</var> is a
+	 * {@link java.awt.Container}.
+	 *
+	 * @param c
+	 *            The component to unregister as a drop target
+	 * @since 1.0
+	 */
+	public static boolean remove(final java.awt.Component c) {
+		return remove(null, c, true);
+	} // end remove
+
+	/**
+	 * Removes the drag-and-drop hooks from the component and optionally from
+	 * the all children. You should call this if you add and remove components
+	 * after you've set up the drag-and-drop.
+	 *
+	 * @param out
+	 *            Optional {@link java.io.PrintStream} for logging drag and drop
+	 *            messages
+	 * @param c
+	 *            The component to unregister
+	 * @param recursive
+	 *            Recursively unregister components within a container
+	 * @since 1.0
+	 */
+	protected static boolean remove(final java.io.PrintStream out, final java.awt.Component c,
+			final boolean recursive) { // Make sure we support dnd.
+		if (supportsDnD()) {
+			log(out, "FileDrop: Removing drag-and-drop hooks.");
+			c.setDropTarget(null);
+			if (recursive && (c instanceof java.awt.Container)) {
+				final java.awt.Component[] comps = ((java.awt.Container) c)
+						.getComponents();
+				for (int i = 0; i < comps.length; i++)
+					remove(out, comps[i], recursive);
+				return true;
+			} // end if: recursive
+			else
+				return false;
+		} // end if: supports DnD
+		else
+			return false;
+	} // end remove
+
+	/* ******** I N N E R I N T E R F A C E L I S T E N E R ******** */
+
+	/**
+	 * Implement this inner interface to listen for when files are dropped. For
+	 * example your class declaration may begin like this:
+	 * <pre>
+	 *      public class MyClass implements FileDrop.Listener
+	 *      ...
+	 *      public void filesDropped( java.io.File[] files )
+	 *      {
+	 *          ...
+	 *      }   // end filesDropped
+	 *      ...
+	 * </pre>
+	 *
+	 * @since 1.1
+	 */
+	public static interface Listener {
+
+		/**
+		 * This method is called when files have been successfully dropped.
+		 *
+		 * @param files
+		 *            An array of <tt>File</tt>s that were dropped.
+		 * @since 1.0
+		 */
+		public abstract void filesDropped(java.io.File[] files);
+
+	} // end inner-interface Listener
+
+	/* ******** I N N E R C L A S S ******** */
+
+	/**
+	 * This is the event that is passed to the
+	 * {@link FileDrop.Listener#filesDropped filesDropped(...)} method in your
+	 * {@link FileDrop.Listener} when files are dropped onto a registered drop
+	 * target.
+	 *
+	 * <p>
+	 * I'm releasing this code into the Public Domain. Enjoy.
+	 * </p>
+	 * 
+	 * @author Robert Harder
+	 * @author rob@iharder.net
+	 * @version 1.2
+	 */
+	@SuppressWarnings("serial")
+	static class Event extends java.util.EventObject {
+
+		private final java.io.File[] files;
+
+		/**
+		 * Constructs an {@link Event} with the array of files that were dropped
+		 * and the {@link FileDrop} that initiated the event.
+		 *
+		 * @param files
+		 *            The array of files that were dropped
+		 * @param source
+		 *            The event source
+		 * @since 1.1
+		 */
+		public Event(final java.io.File[] files, final Object source) {
+			super(source);
+			this.files = files;
+		} // end constructor
+
+		/**
+		 * Returns an array of files that were dropped on a registered drop
+		 * target.
+		 *
+		 * @return array of files that were dropped
+		 * @since 1.1
+		 */
+		public java.io.File[] getFiles() {
+			return files;
+		} // end getFiles
+
+	} // end inner class Event
+
+	/* ******** I N N E R C L A S S ******** */
+
+	/**
+	 * At last an easy way to encapsulate your custom objects for dragging and
+	 * dropping in your Java programs! When you need to create a
+	 * {@link java.awt.datatransfer.Transferable} object, use this class to wrap
+	 * your object. For example:
+	 * 
+	 * <pre>
+	 *      ...
+	 *      MyCoolClass myObj = new MyCoolClass();
+	 *      Transferable xfer = new TransferableObject( myObj );
+	 *      ...
+	 * </pre>
+	 * 
+	 * Or if you need to know when the data was actually dropped, like when
+	 * you're moving data out of a list, say, you can use the
+	 * {@link TransferableObject.Fetcher} inner class to return your object Just
+	 * in Time. For example:
+	 * 
+	 * <pre>
+	 *      ...
+	 *      final MyCoolClass myObj = new MyCoolClass();
+	 * 
+	 *      TransferableObject.Fetcher fetcher = new TransferableObject.Fetcher()
+	 *      {   public Object getObject(){ return myObj; }
+	 *      }; // end fetcher
+	 * 
+	 *      Transferable xfer = new TransferableObject( fetcher );
+	 *      ...
+	 * </pre>
+	 *
+	 * The {@link java.awt.datatransfer.DataFlavor} associated with
+	 * {@link TransferableObject} has the representation class
+	 * <tt>net.iharder.dnd.TransferableObject.class</tt> and MIME type
+	 * <tt>application/x-net.iharder.dnd.TransferableObject</tt>. This data
+	 * flavor is accessible via the static {@link #DATA_FLAVOR} property.
+	 *
+	 *
+	 * <p>
+	 * I'm releasing this code into the Public Domain. Enjoy.
+	 * </p>
+	 * 
+	 * @author Robert Harder
+	 * @author rob@iharder.net
+	 * @version 1.2
+	 */
+	static class TransferableObject implements
+			java.awt.datatransfer.Transferable {
+		/**
+		 * The MIME type for {@link #DATA_FLAVOR} is
+		 * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+		 *
+		 * @since 1.1
+		 */
+		public final static String MIME_TYPE = "application/x-net.iharder.dnd.TransferableObject";
+
+		/**
+		 * The default {@link java.awt.datatransfer.DataFlavor} for
+		 * {@link TransferableObject} has the representation class
+		 * <tt>net.iharder.dnd.TransferableObject.class</tt> and the MIME type
+		 * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+		 *
+		 * @since 1.1
+		 */
+		public final static java.awt.datatransfer.DataFlavor DATA_FLAVOR = new java.awt.datatransfer.DataFlavor(
+				FileDrop.TransferableObject.class, MIME_TYPE);
+
+		private Fetcher fetcher;
+		private Object data;
+
+		private java.awt.datatransfer.DataFlavor customFlavor;
+
+		/**
+		 * Creates a new {@link TransferableObject} that wraps <var>data</var>.
+		 * Along with the {@link #DATA_FLAVOR} associated with this class, this
+		 * creates a custom data flavor with a representation class determined
+		 * from <code>data.getClass()</code> and the MIME type
+		 * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+		 *
+		 * @param data
+		 *            The data to transfer
+		 * @since 1.1
+		 */
+		public TransferableObject(final Object data) {
+			this.data = data;
+			this.customFlavor = new java.awt.datatransfer.DataFlavor(
+					data.getClass(), MIME_TYPE);
+		} // end constructor
+
+		/**
+		 * Creates a new {@link TransferableObject} that will return the object
+		 * that is returned by <var>fetcher</var>. No custom data flavor is set
+		 * other than the default {@link #DATA_FLAVOR}.
+		 *
+		 * @see Fetcher
+		 * @param fetcher
+		 *            The {@link Fetcher} that will return the data object
+		 * @since 1.1
+		 */
+		public TransferableObject(final Fetcher fetcher) {
+			this.fetcher = fetcher;
+		} // end constructor
+
+		/**
+		 * Creates a new {@link TransferableObject} that will return the object
+		 * that is returned by <var>fetcher</var>. Along with the
+		 * {@link #DATA_FLAVOR} associated with this class, this creates a
+		 * custom data flavor with a representation class <var>dataClass</var>
+		 * and the MIME type
+		 * <tt>application/x-net.iharder.dnd.TransferableObject</tt>.
+		 *
+		 * @see Fetcher
+		 * @param dataClass
+		 *            The {@link java.lang.Class} to use in the custom data
+		 *            flavor
+		 * @param fetcher
+		 *            The {@link Fetcher} that will return the data object
+		 * @since 1.1
+		 */
+		public TransferableObject(final Class<?> dataClass, final Fetcher fetcher) {
+			this.fetcher = fetcher;
+			this.customFlavor = new java.awt.datatransfer.DataFlavor(dataClass,
+					MIME_TYPE);
+		} // end constructor
+
+		/**
+		 * Returns the custom {@link java.awt.datatransfer.DataFlavor}
+		 * associated with the encapsulated object or <tt>null</tt> if the
+		 * {@link Fetcher} constructor was used without passing a
+		 * {@link java.lang.Class}.
+		 *
+		 * @return The custom data flavor for the encapsulated object
+		 * @since 1.1
+		 */
+		public java.awt.datatransfer.DataFlavor getCustomDataFlavor() {
+			return customFlavor;
+		} // end getCustomDataFlavor
+
+		/* ******** T R A N S F E R A B L E M E T H O D S ******** */
+
+		/**
+		 * Returns a two- or three-element array containing first the custom
+		 * data flavor, if one was created in the constructors, second the
+		 * default {@link #DATA_FLAVOR} associated with
+		 * {@link TransferableObject}, and third the
+		 * {@link java.awt.datatransfer.DataFlavor#stringFlavor}.
+		 *
+		 * @return An array of supported data flavors
+		 * @since 1.1
+		 */
+		@Override
+		public java.awt.datatransfer.DataFlavor[] getTransferDataFlavors() {
+			if (customFlavor != null)
+				return new java.awt.datatransfer.DataFlavor[] { customFlavor,
+						DATA_FLAVOR,
+						java.awt.datatransfer.DataFlavor.stringFlavor }; // end
+																			// flavors
+																			// array
+			else
+				return new java.awt.datatransfer.DataFlavor[] { DATA_FLAVOR,
+						java.awt.datatransfer.DataFlavor.stringFlavor }; // end
+																			// flavors
+																			// array
+		} // end getTransferDataFlavors
+
+		/**
+		 * Returns the data encapsulated in this {@link TransferableObject}. If
+		 * the {@link Fetcher} constructor was used, then this is when the
+		 * {@link Fetcher#getObject getObject()} method will be called. If the
+		 * requested data flavor is not supported, then the
+		 * {@link Fetcher#getObject getObject()} method will not be called.
+		 *
+		 * @param flavor
+		 *            The data flavor for the data to return
+		 * @return The dropped data
+		 * @since 1.1
+		 */
+		@Override
+		public Object getTransferData(final java.awt.datatransfer.DataFlavor flavor)
+				throws java.awt.datatransfer.UnsupportedFlavorException,
+				java.io.IOException {
+			// Native object
+			if (flavor.equals(DATA_FLAVOR))
+				return fetcher == null ? data : fetcher.getObject();
+
+			// String
+			if (flavor.equals(java.awt.datatransfer.DataFlavor.stringFlavor))
+				return fetcher == null ? data.toString() : fetcher.getObject()
+						.toString();
+
+			// We can't do anything else
+			throw new java.awt.datatransfer.UnsupportedFlavorException(flavor);
+		} // end getTransferData
+
+		/**
+		 * Returns <tt>true</tt> if <var>flavor</var> is one of the supported
+		 * flavors. Flavors are supported using the <code>equals(...)</code>
+		 * method.
+		 *
+		 * @param flavor
+		 *            The data flavor to check
+		 * @return Whether or not the flavor is supported
+		 * @since 1.1
+		 */
+		@Override
+		public boolean isDataFlavorSupported(
+				final java.awt.datatransfer.DataFlavor flavor) {
+			// Native object
+			if (flavor.equals(DATA_FLAVOR))
+				return true;
+
+			// String
+			if (flavor.equals(java.awt.datatransfer.DataFlavor.stringFlavor))
+				return true;
+
+			// We can't do anything else
+			return false;
+		} // end isDataFlavorSupported
+
+		/* ******** I N N E R I N T E R F A C E F E T C H E R ******** */
+
+		/**
+		 * Instead of passing your data directly to the
+		 * {@link TransferableObject} constructor, you may want to know exactly
+		 * when your data was received in case you need to remove it from its
+		 * source (or do anyting else to it). When the {@link #getTransferData
+		 * getTransferData(...)} method is called on the
+		 * {@link TransferableObject}, the {@link Fetcher}'s {@link #getObject
+		 * getObject()} method will be called.
+		 *
+		 * @author Robert Harder
+		 * @version 1.1
+		 * @since 1.1
+		 */
+		public static interface Fetcher {
+			/**
+			 * Return the object being encapsulated in the
+			 * {@link TransferableObject}.
+			 *
+			 * @return The dropped object
+			 * @since 1.1
+			 */
+			public abstract Object getObject();
+		} // end inner interface Fetcher
+
+	} // end class TransferableObject
+
+} // end class FileDrop

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
@@ -256,7 +256,7 @@ public class FileSystemTree extends JTree
 		public void leafDoubleClicked(final File file);
 	}
 
-	private final Logger log;
+	final Logger log;
 
 	private ArrayList<LeafListener> leaf_listeners = new ArrayList<>();
 

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
@@ -275,21 +275,6 @@ public class FileSystemTree extends JTree
 		setAutoscrolls(true);
 		setScrollsOnExpand(true);
 		setExpandsSelectedPaths(true);
-		new FileDrop(this, files -> {
-			final List<File> dirs = Arrays.asList(files).stream().filter(f -> f.isDirectory())
-					.collect(Collectors.toList());
-			if (dirs.isEmpty()) {
-				JOptionPane.showMessageDialog(FileSystemTree.this, "Only folders can be dropped into the file tree.",
-						"Invalid Drop", JOptionPane.WARNING_MESSAGE);
-				return;
-			}
-			final boolean confirm = dirs.size() < 4 || (JOptionPane.showConfirmDialog(FileSystemTree.this,
-					"Confirm loading of " + dirs.size() + " folders?", "Confirm?",
-					JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION);
-			if (confirm) {
-				dirs.forEach(dir -> addRootDirectory(dir.getAbsolutePath(), true));
-			}
-		});
 		addTreeWillExpandListener(new TreeWillExpandListener() {
 			@Override
 			public void treeWillExpand(TreeExpansionEvent event) throws ExpandVetoException {

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
@@ -31,10 +31,12 @@ package org.scijava.ui.swing.script;
 
 import java.awt.Color;
 import java.awt.Desktop;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.awt.RenderingHints;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
@@ -172,8 +174,21 @@ class FileSystemTreePanel extends JPanel {
 		return field;
 	}
 
+	private JButton thinButton(final String label) {
+		final JButton b = new JButton(label);
+		final double FACTOR = .25;
+		final Insets insets =b.getMargin();
+		b.setMargin(new Insets(insets.top, (int) (insets.left *
+			FACTOR), insets.bottom, (int) (insets.right * FACTOR)));
+		//b.setBorder(null);
+		// set height to that of searchField. Do not allow vertical resizing
+		b.setPreferredSize(new Dimension(b.getPreferredSize().width, (int) searchField.getPreferredSize().getHeight()));
+		b.setMaximumSize(new Dimension(b.getMaximumSize().width, (int) searchField.getPreferredSize().getHeight()));
+		return b;
+	}
+
 	private JButton addDirectoryButton() {
-		final JButton add_directory = new JButton("<HTML>&#43;");
+		final JButton add_directory = thinButton("<HTML>&#43;");
 		add_directory.setToolTipText("Add a directory");
 		add_directory.addActionListener(e -> {
 			final String folders = tree.getTopLevelFoldersString();
@@ -205,7 +220,7 @@ class FileSystemTreePanel extends JPanel {
 	}
 
 	private JButton removeDirectoryButton() {
-		final JButton remove_directory = new JButton("<HTML>&#8722;");
+		final JButton remove_directory = thinButton("<HTML>&#8722;");
 		remove_directory.setToolTipText("Remove a top-level directory");
 		remove_directory.addActionListener(e -> {
 			final TreePath p = tree.getSelectionPath();
@@ -227,7 +242,7 @@ class FileSystemTreePanel extends JPanel {
 	}
 
 	private JButton searchOptionsButton() {
-		final JButton options = new JButton("<HTML>&#8942;");
+		final JButton options = thinButton("<HTML>&#8942;");
 		options.setToolTipText("Filtering options");
 		final JPopupMenu popup = new JPopupMenu();
 		final JCheckBoxMenuItem jcbmi1 = new JCheckBoxMenuItem("Case Sensitive", isCaseSensitive());
@@ -371,8 +386,8 @@ class FileSystemTreePanel extends JPanel {
 	private class SearchField extends JTextField {
 
 		private static final long serialVersionUID = 7004232238240585434L;
-		private static final String REGEX_HOLDER = "  [?*]";
-		private static final String CASE_HOLDER = "  [Aa]";
+		private static final String REGEX_HOLDER = "[?*]";
+		private static final String CASE_HOLDER = "[Aa]";
 		private static final String DEF_HOLDER = "File filter... ";
 
 		void update() {

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
@@ -62,7 +62,7 @@ import org.scijava.plugin.Parameter;
 
 /**
  * Convenience class for displaying a {@link FileSystemTree} with some bells and
- * whistles, incliding a filter toolbar.
+ * whistles, including a filter toolbar.
  * 
  * @author Albert Cardona
  * @author Tiago Ferreira

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
@@ -1,0 +1,379 @@
+/*
+ * #%L
+ * Script Editor and Interpreter for SciJava script languages.
+ * %%
+ * Copyright (C) 2009 - 2022 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.ui.swing.script;
+
+import java.awt.Color;
+import java.awt.Desktop;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.RenderingHints;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.swing.FocusManager;
+import javax.swing.JButton;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFileChooser;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreePath;
+
+class FileSystemTreePanel extends JPanel {
+
+	private static final long serialVersionUID = -710040159139542578L;
+	private final FileSystemTree tree;
+	private final SearchField searchField;
+	private boolean regex;
+	private boolean caseSensitive;
+
+	FileSystemTreePanel(final FileSystemTree tree) {
+		this.tree = tree;
+		searchField = initializedField();
+		setLayout(new GridBagLayout());
+		final GridBagConstraints bc = new GridBagConstraints();
+		bc.gridx = 0;
+		bc.gridy = 0;
+		bc.weightx = 0;
+		bc.weighty = 0;
+		bc.anchor = GridBagConstraints.NORTHWEST;
+		bc.fill = GridBagConstraints.NONE;
+		add(addDirectoryButton(), bc);
+		bc.gridx = 1;
+		add(removeDirectoryButton(), bc);
+		bc.gridx = 2;
+		bc.fill = GridBagConstraints.BOTH;
+		bc.weightx = 1;
+		add(searchField, bc);
+		bc.fill = GridBagConstraints.NONE;
+		bc.weightx = 0;
+		bc.gridx = 3;
+		add(searchOptionsButton(), bc);
+		bc.gridx = 0;
+		bc.gridwidth = 4;
+		bc.gridy = 1;
+		bc.weightx = 1.0;
+		bc.weighty = 1.0;
+		bc.fill = GridBagConstraints.BOTH;
+		add(tree, bc);
+		addContextualMenuToTree();
+	}
+
+	private SearchField initializedField() {
+		final SearchField field = new SearchField();
+		field.addFocusListener(new FocusAdapter() {
+			@Override
+			public void focusLost(final FocusEvent e) {
+				if (0 == field.getText().length()) {
+					tree.setFileFilter(((f) -> true)); // any // no need to press enter
+				}
+			}
+		});
+		field.addKeyListener(new KeyAdapter() {
+			Pattern pattern = null;
+
+			@Override
+			public void keyPressed(final KeyEvent ke) {
+				if (ke.getKeyCode() == KeyEvent.VK_ENTER) {
+					final String text = field.getText();
+					if (0 == text.length()) {
+						tree.setFileFilter(((f) -> true)); // any
+						return;
+					}
+					
+					if (isRegexEnabled()) { // if ('/' == text.charAt(0)) {
+						// Interpret as a regular expression
+						// Attempt to compile the pattern
+						try {
+							String regex = text; // text.substring(1);
+							if ('^' != regex.charAt(1))
+								regex = "^.*" + regex;
+							if ('$' != regex.charAt(regex.length() - 1))
+								regex += ".*$";
+							pattern = Pattern.compile(regex);
+							field.setForeground(tree.getForeground());
+						} catch (final PatternSyntaxException | StringIndexOutOfBoundsException pse) {
+							// regex is too short to be parseable or is invalid
+							tree.log.warn(pse.getLocalizedMessage());
+							field.setForeground(Color.RED);
+							pattern = null;
+							return;
+						}
+						if (null != pattern) {
+							tree.setFileFilter((f) -> pattern.matcher(f.getName()).matches());
+						}
+					} else {
+						// Interpret as a literal match
+						if (isCaseSensitive())
+							tree.setFileFilter((f) -> -1 != f.getName().indexOf(text));
+						else
+							tree.setFileFilter((f) -> -1 != f.getName().toLowerCase().indexOf(text.toLowerCase()));
+					}
+				} else {
+					// Upon re-typing something
+					if (field.getForeground() == Color.RED) {
+						field.setForeground(tree.getForeground());
+					}
+				}
+			}
+		});
+		return field;
+	}
+
+	private JButton addDirectoryButton() {
+		final JButton add_directory = new JButton("<HTML>&#43;");
+		add_directory.setToolTipText("Add a directory");
+		add_directory.addActionListener(e -> {
+			final String folders = tree.getTopLevelFoldersString();
+			final String lastFolder = folders.substring(folders.lastIndexOf(":") + 1);
+			final JFileChooser c = new JFileChooser();
+			c.setDialogTitle("Choose Top-Level Folder");
+			c.setCurrentDirectory(new File(lastFolder));
+			c.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+			c.setFileHidingEnabled(true); // hide hidden files
+			c.setAcceptAllFileFilterUsed(false); // disable "All files" as it has no meaning here
+			c.setApproveButtonText("Choose Folder");
+			c.setMultiSelectionEnabled(false);
+			c.setDragEnabled(true);
+			new FileDrop(c, files -> {
+				if (files.length == 0)
+					return;
+				final File firstFile = files[0];
+				c.setCurrentDirectory((firstFile.isDirectory()) ? firstFile : firstFile.getParentFile());
+				c.rescanCurrentDirectory();
+			});
+			if (JFileChooser.APPROVE_OPTION == c.showOpenDialog(this)) {
+				final File f = c.getSelectedFile();
+				if (f.isDirectory())
+					tree.addRootDirectory(f.getAbsolutePath(), false);
+			}
+			FileDrop.remove(c);
+		});
+		return add_directory;
+	}
+
+	private JButton removeDirectoryButton() {
+		final JButton remove_directory = new JButton("<HTML>&#8722;");
+		remove_directory.setToolTipText("Remove a top-level directory");
+		remove_directory.addActionListener(e -> {
+			final TreePath p = tree.getSelectionPath();
+			if (null == p) {
+				JOptionPane.showMessageDialog(this, "Select a top-level folder first.", "Invalid Folder",
+						JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+			if (2 == p.getPathCount()) {
+				// Is a child of the root, so it's a top-level folder
+				tree.getModel().removeNodeFromParent(//
+						(FileSystemTree.Node) p.getLastPathComponent());
+			} else {
+				JOptionPane.showMessageDialog(this, "Can only remove top-level folders.", "Invalid Folder",
+						JOptionPane.ERROR_MESSAGE);
+			}
+		});
+		return remove_directory;
+	}
+
+	private JButton searchOptionsButton() {
+		final JButton options = new JButton("<HTML>&#8942;");
+		options.setToolTipText("Filtering options");
+		final JPopupMenu popup = new JPopupMenu();
+		final JCheckBoxMenuItem jcbmi1 = new JCheckBoxMenuItem("Case Sensitive", isCaseSensitive());
+		jcbmi1.addItemListener(e -> {
+			setCaseSensitive(jcbmi1.isSelected());
+		});
+		popup.add(jcbmi1);
+		final JCheckBoxMenuItem jcbmi2 = new JCheckBoxMenuItem("Enable Regex", isCaseSensitive());
+		jcbmi2.addItemListener(e -> {
+			setRegexEnabled(jcbmi2.isSelected());
+		});
+		popup.add(jcbmi2);
+		popup.addSeparator();
+		JMenuItem jmi = new JMenuItem("Reset Filter");
+		jmi.addActionListener(e -> {
+			searchField.setText("");
+			tree.setFileFilter(((f) -> true));
+		});
+		popup.add(jmi);
+		popup.addSeparator();
+		jmi = new JMenuItem("Context Help...");
+		jmi.addActionListener(e -> showHelpMsg());
+		popup.add(jmi);
+		options.addActionListener(e -> popup.show(options, options.getWidth() / 2, options.getHeight() / 2));
+		return options;
+	}
+
+	@SuppressWarnings("unused")
+	private boolean allTreeNodesCollapsed() {
+		for (int i = 0; i < tree.getRowCount(); i++)
+			if (!tree.isCollapsed(i)) return false;
+		return true;
+	}
+
+	private void addContextualMenuToTree() {
+		final JPopupMenu popup = new JPopupMenu();
+		JMenuItem jmi = new JMenuItem("Collapse All");
+		jmi.addActionListener(e -> {
+			SwingUtilities.invokeLater(() -> {
+				for (int i = tree.getRowCount() - 1; i >= 0; i--)
+					tree.collapseRow(i);
+			});
+		});
+		popup.add(jmi);
+		jmi = new JMenuItem("Expand All Folders");
+		jmi.addActionListener(e -> {
+			SwingUtilities.invokeLater(() -> {
+				for (int i = tree.getRowCount() - 1; i >= 0; i--)
+					tree.expandRow(i);
+			});
+		});
+		popup.add(jmi);
+		popup.addSeparator();
+		jmi = new JMenuItem("Show in System Explorer");
+		jmi.addActionListener(e -> {
+			final TreePath path = tree.getSelectionPath();
+			if (path == null) {
+				JOptionPane.showMessageDialog(this, "No items are currently selected.",
+						"Invalid Selection", JOptionPane.INFORMATION_MESSAGE);
+				return;
+			}
+			try {
+				final String filepath = (String) ((FileSystemTree.Node) path.getLastPathComponent()).getUserObject();
+				final File f = new File(filepath);
+				Desktop.getDesktop().open((f.isDirectory()) ? f : f.getParentFile());
+			} catch (final Exception | Error ignored) {
+				JOptionPane.showMessageDialog(this,
+						"Folder of selected item does not seem to be accessible.", "Error", JOptionPane.ERROR_MESSAGE);
+			}
+		});
+		popup.add(jmi);
+		popup.addSeparator();
+		jmi = new JMenuItem("Reset Tree to Home Folder");
+		jmi.addActionListener(e -> {
+			((DefaultMutableTreeNode) tree.getModel().getRoot()).removeAllChildren();
+			tree.addTopLevelFoldersFrom(System.getProperty("user.home"));
+		});
+		popup.add(jmi);
+		tree.setComponentPopupMenu(popup);
+	}
+
+	private void showHelpMsg() {
+		final String msg = "<HTML><div WIDTH=650>" //
+				+ "<p><b>Overview</b></p>" //
+				+ "<p>The File Explorer provides a direct view of selected folders. Changes in " //
+				+ "the native file system are synchronized in real time.</p>" //
+				+ "<br><p><b>Add/Remove Folders</b></p>" //
+				+ "<p>To add a folder, use the [+] button, or drag &amp; drop folders from the native " //
+				+ "System Explorer. To remove a folder: select it, then use the [-] button. To reset "
+				+ "or reveal items: use the commands in the contextual popup menu.</p>" //
+				+ "<br><p><b>Filtering Files</b></p>" //
+				+ "<p>Filters affect only filenames (not folders) and are applied by typing a "// 
+				+ "filtering string and pressing [Enter]. Filters act only on files being listed, " //
+				+ "and ignore collapsed folders. Examples of regex usage:</p>" //
+				+ "<br><table align='center'>" //
+				+ " <thead>" //
+				+ "  <tr>" //
+				+ "   <th>Pattern</th>" //
+				+ "   <th>Result</th>" //
+				+ "  </tr>" //
+				+ " </thead>" //
+				+ " <tbody>" //
+				+ "  <tr>" //
+				+ "   <td>py$</td>" //
+				+ "   <td>Display filenames ending with <i>py</i></td>" //
+				+ "  </tr>" //
+				+ "  <tr>" //
+				+ "   <td>^Demo</td>" //
+				+ "   <td>Display filenames starting with <i>Demo</i></td>" //
+				+ "  </tr>" //
+				+ " </tbody>" //
+				+ "</table>";
+		JOptionPane.showMessageDialog(this, msg, "File Explorer", JOptionPane.PLAIN_MESSAGE);
+	}
+
+	private boolean isCaseSensitive() {
+		return caseSensitive;
+	}
+
+	private boolean isRegexEnabled() {
+		return regex;
+	}
+
+	private void setCaseSensitive(final boolean b) {
+		caseSensitive = b;
+		searchField.update();
+	}
+
+	private void setRegexEnabled(final boolean b) {
+		regex = b;
+		searchField.update();
+	}
+
+	private class SearchField extends JTextField {
+
+		private static final long serialVersionUID = 7004232238240585434L;
+		private static final String REGEX_HOLDER = "  [?*]";
+		private static final String CASE_HOLDER = "  [Aa]";
+		private static final String DEF_HOLDER = "File filter... ";
+
+		void update() {
+			update(getGraphics());
+		}
+
+		@Override
+		protected void paintComponent(final java.awt.Graphics g) {
+			super.paintComponent(g);
+			if (super.getText().isEmpty() && !(FocusManager.getCurrentKeyboardFocusManager().getFocusOwner() == this)) {
+				final Graphics2D g2 = (Graphics2D) g.create();
+				g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+				g2.setColor(Color.GRAY);
+				g2.setFont(getFont().deriveFont(Font.ITALIC));
+				final StringBuilder sb = new StringBuilder(DEF_HOLDER);
+				if (isCaseSensitive())
+					sb.append(CASE_HOLDER);
+				if (isRegexEnabled())
+					sb.append(REGEX_HOLDER);
+				g2.drawString(sb.toString(), 4, g2.getFontMetrics().getHeight());
+				g2.dispose();
+			}
+		}
+	}
+}

--- a/src/main/java/org/scijava/ui/swing/script/FindAndReplaceDialog.java
+++ b/src/main/java/org/scijava/ui/swing/script/FindAndReplaceDialog.java
@@ -80,8 +80,8 @@ public class FindAndReplaceDialog extends JDialog implements ActionListener {
 		c.ipadx = c.ipady = 1;
 		c.fill = GridBagConstraints.HORIZONTAL;
 		c.anchor = GridBagConstraints.LINE_START;
-		searchField = createField("Find Next", text, c, null);
-		replaceField = createField("Replace with", text, c, this);
+		searchField = createField("Find: ", text, c, null);
+		replaceField = createField("Replace with: ", text, c, this);
 
 		c.gridwidth = 4;
 		c.gridheight = c.gridy;
@@ -95,14 +95,14 @@ public class FindAndReplaceDialog extends JDialog implements ActionListener {
 		c.gridwidth = 1;
 		c.gridheight = 1;
 		c.weightx = 0.001;
-		matchCase = createCheckBox("Match Case", root, c);
+		matchCase = createCheckBox("Match case", root, c);
 		regex = createCheckBox("Regex", root, c);
 		forward = createCheckBox("Search forward", root, c);
 		forward.setSelected(true);
 		c.gridx = 0;
 		c.gridy++;
-		markAll = createCheckBox("Mark All", root, c);
-		wholeWord = createCheckBox("Whole Word", root, c);
+		markAll = createCheckBox("Mark all", root, c);
+		wholeWord = createCheckBox("Whole word", root, c);
 
 		c.gridx = 4;
 		c.gridy = 0;
@@ -137,7 +137,7 @@ public class FindAndReplaceDialog extends JDialog implements ActionListener {
 
 	@Override
 	public void show(final boolean replace) {
-		setTitle(replace ? "Replace" : "Find");
+		setTitle(replace ? "Find/Replace" : "Find");
 		replaceLabel.setEnabled(replace);
 		replaceField.setEnabled(replace);
 		replaceField.setBackground(replace ? searchField.getBackground()

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -218,7 +218,8 @@ public class TextEditor extends JFrame implements ActionListener,
 			openMacroFunctions, decreaseFontSize, increaseFontSize, chooseFontSize,
 			chooseTabSize, gitGrep, replaceTabsWithSpaces,
 			replaceSpacesWithTabs, toggleWhiteSpaceLabeling, zapGremlins,
-			savePreferences, toggleAutoCompletionMenu, openClassOrPackageHelp;
+			savePreferences, toggleAutoCompletionMenu, toggleAutoCompletionKeyRequired,
+			openClassOrPackageHelp;
 	private RecentFilesMenuItem openRecent;
 	private JMenu gitMenu, tabsMenu, fontSizeMenu, tabSizeMenu, toolsMenu,
 			runMenu, whiteSpaceMenu;
@@ -605,6 +606,10 @@ public class TextEditor extends JFrame implements ActionListener,
 		toggleAutoCompletionMenu.setSelected(prefService.getBoolean(TextEditor.class, "autoComplete", true));
 		toggleAutoCompletionMenu.addChangeListener(e -> toggleAutoCompletion());
 		options.add(toggleAutoCompletionMenu);
+		toggleAutoCompletionKeyRequired = new JCheckBoxMenuItem("Auto-completion Requires Ctrl+Space");
+		toggleAutoCompletionKeyRequired.setSelected(prefService.getBoolean(TextEditor.class, "autoCompleteKeyRequired", true));
+		toggleAutoCompletionKeyRequired.addChangeListener(e -> toggleAutoCompletionKeyRequired());
+		options.add(toggleAutoCompletionKeyRequired);
 
 		options.addSeparator();
 		savePreferences = addToMenu(options, "Save Preferences", 0, 0);
@@ -1466,6 +1471,14 @@ public class TextEditor extends JFrame implements ActionListener,
 			editorPane.setAutoCompletionEnabled(toggleAutoCompletionMenu.isSelected());
 		}
 		prefService.put(TextEditor.class, "autoComplete", toggleAutoCompletionMenu.isSelected());
+	}
+
+	private void toggleAutoCompletionKeyRequired() {
+		for (int i = 0; i < tabbed.getTabCount(); i++) {
+			final EditorPane editorPane = getEditorPane(i);
+			editorPane.setAutoCompletionEnabled(toggleAutoCompletionKeyRequired.isSelected());
+		}
+		prefService.put(TextEditor.class, "autoCompleteKeyRequired", toggleAutoCompletionKeyRequired.isSelected());
 	}
 
 	protected boolean handleTabsMenu(final Object source) {

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -683,7 +683,7 @@ public class TextEditor extends JFrame implements ActionListener,
 						"Could not open the file at: " + f.getAbsolutePath());
 					return;
 				}
-				catch (Exception e) {
+				catch (final Exception e) {
 					log.error(e);
 					error("Could not open image at " + f);
 				}
@@ -768,6 +768,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 		});
 
+		// Tweaks for Console
 		errorScreen.setFont(getEditorPane().getFont());
 		errorScreen.setEditable(false);
 		errorScreen.setLineWrap(true);
@@ -811,19 +812,19 @@ public class TextEditor extends JFrame implements ActionListener,
 		final EditorPane editorPane = getEditorPane();
 		editorPane.requestFocus();
 	}
-	
+
 	private class DragAndDrop implements DragSourceListener, DragGestureListener {
 		@Override
-		public void dragDropEnd(DragSourceDropEvent dsde) {}
+		public void dragDropEnd(final DragSourceDropEvent dsde) {}
 
 		@Override
-		public void dragEnter(DragSourceDragEvent dsde) {
+		public void dragEnter(final DragSourceDragEvent dsde) {
 			dsde.getDragSourceContext().setCursor(DragSource.DefaultMoveNoDrop);
 		}
 
 		@Override
-		public void dragGestureRecognized(DragGestureEvent dge) {
-			TreePath path = tree.getSelectionPath();
+		public void dragGestureRecognized(final DragGestureEvent dge) {
+			final TreePath path = tree.getSelectionPath();
 			if (path == null) // nothing is currently selected
 				return;
 			final String filepath = (String)((FileSystemTree.Node) path.getLastPathComponent()).getUserObject();
@@ -839,7 +840,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				}
 				
 				@Override
-				public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+				public Object getTransferData(final DataFlavor flavor) throws UnsupportedFlavorException, IOException {
 					if (isDataFlavorSupported(flavor))
 						return Arrays.asList(new String[]{filepath});
 					return null;
@@ -848,12 +849,12 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		@Override
-		public void dragExit(DragSourceEvent dse) {
+		public void dragExit(final DragSourceEvent dse) {
 			dse.getDragSourceContext().setCursor(DragSource.DefaultMoveNoDrop);
 		}
 
 		@Override
-		public void dragOver(DragSourceDragEvent dsde) {
+		public void dragOver(final DragSourceDragEvent dsde) {
 			if (tree == dsde.getSource()) {
 				dsde.getDragSourceContext().setCursor(DragSource.DefaultCopyNoDrop);
 			} else if (dsde.getDropAction() == DnDConstants.ACTION_COPY) {
@@ -864,7 +865,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 
 		@Override
-		public void dropActionChanged(DragSourceDragEvent dsde) {}
+		public void dropActionChanged(final DragSourceDragEvent dsde) {}
 	}
 
 	public LogService log() { return log; }
@@ -1440,7 +1441,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			item.addActionListener(e -> {
 				try {
 					applyTheme(v);
-				} catch (IllegalArgumentException ex) {
+				} catch (final IllegalArgumentException ex) {
 					JOptionPane.showMessageDialog(TextEditor.this,
 							"An exception occured. Theme could not be loaded");
 					ex.printStackTrace();
@@ -1642,7 +1643,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		if (isBinary(file)) {
 			try {
 				uiService.show(ioService.open(file.getAbsolutePath()));
-			} catch (IOException e) {
+			} catch (final IOException e) {
 				log.error(e);
 			}
 			return null;
@@ -1650,7 +1651,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		try {
 			TextEditorTab tab = (tabbed.getTabCount() == 0) ? null : getTab();
-			TextEditorTab prior = tab;
+			final TextEditorTab prior = tab;
 			final boolean wasNew = tab != null && tab.editorPane.isNew();
 			float font_size = 0; // to set the new editor's font like the last active one, if any
 			if (!wasNew) {
@@ -2340,7 +2341,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		final String path = getPromptCommandsFilename(language);
 		final File file = new File(path);
 		try {
-			boolean exists = file.exists();
+			final boolean exists = file.exists();
 			if (!exists) {
 				// Ensure parent directories exist
 				file.getParentFile().mkdirs();
@@ -2348,7 +2349,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 			Files.write(Paths.get(path), Arrays.asList(new String[]{text, "#"}), Charset.forName("UTF-8"),
 					StandardOpenOption.APPEND, StandardOpenOption.DSYNC);
-		} catch (IOException e) {
+		} catch (final IOException e) {
 			log.error("Failed to write executed prompt command to file " + path, e);
 		}
 	}
@@ -2374,11 +2375,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			final String sep = System.getProperty("line.separator"); // used fy Files.write above
 			commands.addAll(Arrays.asList(new String(bytes, Charset.forName("UTF-8")).split(sep + "#" + sep)));
 			if (0 == commands.get(commands.size()-1).length()) commands.remove(commands.size() -1); // last entry is empty
-		} catch (IOException e) {
+		} catch (final IOException e) {
 			log.error("Failed to read history of prompt commands from file " + path, e);
 			return lines;
 		} finally {
-			try { if (null != ra) ra.close(); } catch (IOException e) { log.error(e); }
+			try { if (null != ra) ra.close(); } catch (final IOException e) { log.error(e); }
 		}
 		if (commands.size() > 1000) {
 			commands = commands.subList(commands.size() - 1000, commands.size());
@@ -2394,7 +2395,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				if (!new File(path + "-tmp").renameTo(new File(path))) {
 					log.error("Could not rename command log file " + path + "-tmp to " + path);
 				}
-			} catch (Exception e) {
+			} catch (final Exception e) {
 				log.error("Failed to crop history of prompt commands file " + path, e);
 			}
 		}
@@ -2717,7 +2718,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			final GridBagLayout gridbag = new GridBagLayout();
 			final GridBagConstraints c = new GridBagConstraints();
 			panel.setLayout(gridbag);
-			panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+			panel.setBorder(BorderFactory.createEmptyBorder(BORDER_SIZE, BORDER_SIZE, BORDER_SIZE, BORDER_SIZE));
 			final List<String> keys = new ArrayList<String>(matches.keySet());
 			Collections.sort(keys);
 			c.gridy = 0;
@@ -2741,13 +2742,11 @@ public class TextEditor extends JFrame implements ActionListener,
 					final JButton link = new JButton(title);
 					gridbag.setConstraints(link, c);
 					panel.add(link);
-					link.addActionListener(new ActionListener() {
-						public void actionPerformed(final ActionEvent event) {
-							try {
-								platformService.open(new URL(url));
-							} catch (Exception e) {
-								e.printStackTrace();
-							}
+					link.addActionListener(event -> {
+						try {
+							platformService.open(new URL(url));
+						} catch (final Exception e) {
+							e.printStackTrace();
 						}
 					});
 				}
@@ -2920,7 +2919,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			try {
 				// Same engine, with persistent state
 				this.scriptInfo.setScript( reader );
-			} catch (IOException e) {
+			} catch (final IOException e) {
 				log.error(e);
 			}
 		}
@@ -2988,7 +2987,7 @@ public class TextEditor extends JFrame implements ActionListener,
 							execute(getTab(), text, true);
 							prompt.setText("");
 							screen.scrollRectToVisible(screen.modelToView(screen.getDocument().getLength()));
-						} catch (Throwable t) {
+						} catch (final Throwable t) {
 							log.error(t);
 						}
 						ke.consume(); // avoid writing the line break

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -88,6 +88,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.Vector;
@@ -1984,6 +1985,8 @@ public class TextEditor extends JFrame implements ActionListener,
 		updateUI(true);
 	}
 
+	private String lastSupportStatus = null;
+
 	void updateLanguageMenu(final ScriptLanguage language) {
 		JMenuItem item = languageMenuItems.get(language);
 		if (item == null) item = noneLanguageItem;
@@ -1991,8 +1994,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			item.setSelected(true);
 		}
 		// print autocompletion status to console
-		if (getEditorPane().getSupportStatus() != null)
-			write(getEditorPane().getSupportStatus());
+		String supportStatus = getEditorPane().getSupportStatus();
+		if (supportStatus != null && !Objects.equals(supportStatus, lastSupportStatus)) {
+			write(supportStatus);
+			lastSupportStatus = supportStatus;
+		}
 
 		final boolean isRunnable = item != noneLanguageItem;
 		final boolean isCompileable =

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -297,13 +297,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		// NB: All panes must be initialized before menus are assembled!
 		tabbed = new JTabbedPane();
 		tree = new FileSystemTree(log);
-		final JScrollPane scrolltree = new JScrollPane(new FileSystemTreePanel(tree, context));
-		// set borders. Needed for drag & drop and collapsing split pane
-		//tabbed.setBorder(BorderFactory.createEmptyBorder(0,BORDER_SIZE,0,BORDER_SIZE));
-		//scrolltree.setBorder(BorderFactory.createEmptyBorder(0,0,0,BORDER_SIZE));
-		scrolltree.setPreferredSize(new Dimension(200, 600));
-		body = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, scrolltree, tabbed);
-
+		body = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, new FileSystemTreePanel(tree, context), tabbed);
 		// These items are dynamic and need to be initialized before EditorPane creation
 		initializeDynamicMenuComponents();
 
@@ -2317,8 +2311,17 @@ public class TextEditor extends JFrame implements ActionListener,
 	 * Run current script with the batch processor
 	 */
 	public void runBatch() {
+		if (null == getCurrentLanguage()) {
+			error("Select a language first! Also, please note that this option\n"
+				+ "requires at least one @File parameter to be declared in the script.");
+			return;
+		}
 		// get script from current tab
 		final String script = getTab().getEditorPane().getText();
+		if (script.trim().isEmpty()) {
+			error("This option requires at least one @File parameter to be declared.");
+			return;
+		}
 		final ScriptInfo info = new ScriptInfo(context, //
 			"dummy." + getCurrentLanguage().getExtensions().get(0), //
 			new StringReader(script));

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -647,7 +647,6 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		// Tweaks for FileSystemTree
 		tree.addTopLevelFoldersFrom(getEditorPane().loadFolders()); // Restore top-level directories
-		tree.setFont(tree.getFont().deriveFont(getEditorPane().getFontSize()));
 		dragSource = new DragSource();
 		dragSource.createDefaultDragGestureRecognizer(tree, DnDConstants.ACTION_COPY, new DragAndDrop());
 		tree.ignoreExtension("class");
@@ -802,7 +801,9 @@ public class TextEditor extends JFrame implements ActionListener,
 		final EditorPane editorPane = getEditorPane();
 		// If dark L&F and using the default theme, assume 'dark' theme
 		applyTheme((isDarkLaF() && "default".equals(editorPane.themeName())) ? "dark" : editorPane.themeName());
-		// Apply preferences that have not yet been set
+		// Ensure font sizes are consistent across all panels
+		setFontSize(getEditorPane().getFontSize());
+		// Ensure menu commands are up-to-date
 		updateUI(true);
 		// Store locations of splitpanes
 		panePositions = new int[]{body.getDividerLocation(), getTab().getScreenAndPromptSplit().getDividerLocation()};
@@ -1515,7 +1516,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			final Theme th = Theme
 					.load(getClass().getResourceAsStream("/org/fife/ui/rsyntaxtextarea/themes/" + theme + ".xml"));
 			for (int i = 0; i < tabbed.getTabCount(); i++) {
-				th.apply(getEditorPane(i));
+				// themes include font size, so we'll need to reset that
+				final EditorPane ep = getEditorPane(i);
+				final float existingFontSize = ep.getFontSize();
+				th.apply(ep);
+				ep.setFontSize(existingFontSize);
 			}
 		} catch (final Exception ex) {
 			throw new IllegalArgumentException(ex);

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -32,7 +32,6 @@ package org.scijava.ui.swing.script;
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Toolkit;
@@ -123,6 +122,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -212,7 +212,8 @@ public class TextEditor extends JFrame implements ActionListener,
 			close, undo, redo, cut, copy, paste, find, replace, selectAll, kill,
 			gotoLine, makeJar, makeJarWithSource, removeUnusedImports, sortImports,
 			removeTrailingWhitespace, findNext, findPrevious, openHelp, addImport,
-			clearScreen, nextError, previousError, openHelpWithoutFrames, nextTab,
+			//clearScreen, redundant with "Clear" JButton
+			nextError, previousError, openHelpWithoutFrames, nextTab,
 			previousTab, runSelection, extractSourceJar, toggleBookmark,
 			listBookmarks, openSourceForClass, openSourceForMenuItem,
 			openMacroFunctions, decreaseFontSize, increaseFontSize, chooseFontSize,
@@ -305,14 +306,15 @@ public class TextEditor extends JFrame implements ActionListener,
 		openRecent = new RecentFilesMenuItem(prefService, this);
 		openRecent.setMnemonic(KeyEvent.VK_R);
 		file.add(openRecent);
+		file.addSeparator();
 		save = addToMenu(file, "Save", KeyEvent.VK_S, ctrl);
 		save.setMnemonic(KeyEvent.VK_S);
-		saveas = addToMenu(file, "Save as...", 0, 0);
+		saveas = addToMenu(file, "Save As...", 0, 0);
 		saveas.setMnemonic(KeyEvent.VK_A);
 		file.addSeparator();
-		makeJar = addToMenu(file, "Export as .jar", 0, 0);
+		makeJar = addToMenu(file, "Export as JAR", 0, 0);
 		makeJar.setMnemonic(KeyEvent.VK_E);
-		makeJarWithSource = addToMenu(file, "Export as .jar (with source)", 0, 0);
+		makeJarWithSource = addToMenu(file, "Export as JAR (With Source)", 0, 0);
 		makeJarWithSource.setMnemonic(KeyEvent.VK_X);
 		file.addSeparator();
 		close = addToMenu(file, "Close", KeyEvent.VK_W, ctrl);
@@ -330,7 +332,7 @@ public class TextEditor extends JFrame implements ActionListener,
 		cut = addToMenu(edit, "Cut", KeyEvent.VK_X, ctrl);
 		copy = addToMenu(edit, "Copy", KeyEvent.VK_C, ctrl);
 		paste = addToMenu(edit, "Paste", KeyEvent.VK_V, ctrl);
-		edit.addSeparator();
+		addSeparator(edit, "Find:");
 		find = addToMenu(edit, "Find...", KeyEvent.VK_F, ctrl);
 		find.setMnemonic(KeyEvent.VK_F);
 		findNext = addToMenu(edit, "Find Next", KeyEvent.VK_F3, 0);
@@ -338,16 +340,18 @@ public class TextEditor extends JFrame implements ActionListener,
 		findPrevious = addToMenu(edit, "Find Previous", KeyEvent.VK_F3, shift);
 		findPrevious.setMnemonic(KeyEvent.VK_P);
 		replace = addToMenu(edit, "Find and Replace...", KeyEvent.VK_H, ctrl);
-		gotoLine = addToMenu(edit, "Goto line...", KeyEvent.VK_G, ctrl);
+
+		addSeparator(edit, "Goto:");
+		gotoLine = addToMenu(edit, "Goto Line...", KeyEvent.VK_G, ctrl);
 		gotoLine.setMnemonic(KeyEvent.VK_G);
 		toggleBookmark = addToMenu(edit, "Toggle Bookmark", KeyEvent.VK_B, ctrl);
 		toggleBookmark.setMnemonic(KeyEvent.VK_B);
-		listBookmarks = addToMenu(edit, "List Bookmarks", 0, 0);
+		listBookmarks = addToMenu(edit, "List Bookmarks...", 0, 0);
 		listBookmarks.setMnemonic(KeyEvent.VK_O);
-		edit.addSeparator();
 
-		clearScreen = addToMenu(edit, "Clear output panel", 0, 0);
-		clearScreen.setMnemonic(KeyEvent.VK_L);
+		// This is redundant with 'Clear' JButton
+//		clearScreen = addToMenu(edit, "Clear output panel", 0, 0);
+//		clearScreen.setMnemonic(KeyEvent.VK_L);
 
 		zapGremlins = addToMenu(edit, "Zap Gremlins", 0, 0);
 
@@ -456,12 +460,12 @@ public class TextEditor extends JFrame implements ActionListener,
 		compileAndRun.setMnemonic(KeyEvent.VK_R);
 
 		runSelection =
-			addToMenu(runMenu, "Run selected code", KeyEvent.VK_R, ctrl | shift);
+			addToMenu(runMenu, "Run Selected Code", KeyEvent.VK_R, ctrl | shift);
 		runSelection.setMnemonic(KeyEvent.VK_S);
 
 		compile = addToMenu(runMenu, "Compile", KeyEvent.VK_C, ctrl | shift);
 		compile.setMnemonic(KeyEvent.VK_C);
-		autoSave = new JCheckBoxMenuItem("Auto-save before compiling");
+		autoSave = new JCheckBoxMenuItem("Auto-save Before Compiling");
 		runMenu.add(autoSave);
 
 		runMenu.addSeparator();
@@ -472,7 +476,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		runMenu.addSeparator();
 
-		kill = addToMenu(runMenu, "Kill running script...", 0, 0);
+		kill = addToMenu(runMenu, "Kill Running Script...", 0, 0);
 		kill.setMnemonic(KeyEvent.VK_K);
 		kill.setEnabled(false);
 
@@ -539,14 +543,15 @@ public class TextEditor extends JFrame implements ActionListener,
 		options.setMnemonic(KeyEvent.VK_O);
 
 		// Font adjustments
+		addSeparator(options, "Font:");
 		decreaseFontSize =
-			addToMenu(options, "Decrease font size", KeyEvent.VK_MINUS, ctrl);
+			addToMenu(options, "Decrease Font Size", KeyEvent.VK_MINUS, ctrl);
 		decreaseFontSize.setMnemonic(KeyEvent.VK_D);
 		increaseFontSize =
-			addToMenu(options, "Increase font size", KeyEvent.VK_PLUS, ctrl);
+			addToMenu(options, "Increase Font Size", KeyEvent.VK_PLUS, ctrl);
 		increaseFontSize.setMnemonic(KeyEvent.VK_C);
 
-		fontSizeMenu = new JMenu("Font sizes");
+		fontSizeMenu = new JMenu("Font Size");
 		fontSizeMenu.setMnemonic(KeyEvent.VK_Z);
 		final boolean[] fontSizeShortcutUsed = new boolean[10];
 		final ButtonGroup buttonGroup = new ButtonGroup();
@@ -828,8 +833,7 @@ public class TextEditor extends JFrame implements ActionListener,
 			}
 		});
 
-		final Font font = new Font("Courier", Font.PLAIN, 12);
-		errorScreen.setFont(font);
+		errorScreen.setFont(getEditorPane().getFont());
 		errorScreen.setEditable(false);
 		errorScreen.setLineWrap(true);
 
@@ -1397,13 +1401,13 @@ public class TextEditor extends JFrame implements ActionListener,
 			.convertTabsToSpaces();
 		else if (source == replaceSpacesWithTabs) getTextArea()
 			.convertSpacesToTabs();
-		else if (source == clearScreen) {
-			getTab().getScreen().setText("");
-		}
+//		else if (source == clearScreen) {
+//			getTab().getScreen().setText("");
+//		}
 		else if (source == zapGremlins) zapGremlins();
-		else if (source == toggleAutoCompletionMenu) {
-			toggleAutoCompletion();
-		}
+//		else if (source == toggleAutoCompletionMenu) {
+//			toggleAutoCompletion();
+//		}
 		else if (source == savePreferences) {
 			getEditorPane().savePreferences(tree.getTopLevelFoldersString());
 		}
@@ -1558,9 +1562,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			final TextEditorTab tab = (TextEditorTab) tabbed.getComponentAt(i);
 			tab.editorPane.getBookmarks(tab, bookmarks);
 		}
-
-		final BookmarkDialog dialog = new BookmarkDialog(this, bookmarks);
-		dialog.setVisible(true);
+		if (bookmarks.isEmpty()) {
+			JOptionPane.showMessageDialog(this, "No Bookmarks currently exist.");
+		} else {
+			new BookmarkDialog(this, bookmarks).setVisible(true);
+		}
 	}
 
 	public boolean reload() {
@@ -3133,5 +3139,24 @@ public class TextEditor extends JFrame implements ActionListener,
 
 	private void changeFontSize(final JTextArea a, final float size) {
 		a.setFont(a.getFont().deriveFont(size));
+	}
+
+	private static void addSeparator(final JMenu menu, final String header) {
+		final JLabel label = new JLabel(header);
+		// label.setHorizontalAlignment(SwingConstants.LEFT);
+		label.setEnabled(false);
+		label.setForeground(getDisabledComponentColor());
+		if (menu.getMenuComponentCount() > 1) {
+			menu.addSeparator();
+		}
+		menu.add(label);
+	}
+
+	private static Color getDisabledComponentColor() {
+		try {
+			return UIManager.getColor("MenuItem.disabledForeground");
+		} catch (final Exception ignored) {
+			return Color.GRAY;
+		}
 	}
 }

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -1977,12 +1977,11 @@ public class TextEditor extends JFrame implements ActionListener,
 			this.scriptInfo = null;
 		}
 		getEditorPane().setLanguage(language, addHeader);
-		
 		prefService.put(getClass(), LAST_LANGUAGE, null == language? "none" : language.getLanguageName());
 
 		setTitle();
 		updateLanguageMenu(language);
-		updateTabAndFontSize(true);
+		updateUI(true);
 	}
 
 	void updateLanguageMenu(final ScriptLanguage language) {
@@ -1991,6 +1990,9 @@ public class TextEditor extends JFrame implements ActionListener,
 		if (!item.isSelected()) {
 			item.setSelected(true);
 		}
+		// print autocompletion status to console
+		if (getEditorPane().getSupportStatus() != null)
+			write(getEditorPane().getSupportStatus());
 
 		final boolean isRunnable = item != noneLanguageItem;
 		final boolean isCompileable =

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -188,7 +188,7 @@ public class TextEditorTab extends JSplitPane {
 		bottom.add(killit, bc);
 		
 		bc.gridx = 3;
-		incremental = new JCheckBox("persistent");
+		incremental = new JCheckBox("Persistent");
 		incremental.setEnabled(true);
 		incremental.setSelected(false);
 		bottom.add(incremental, bc);
@@ -291,7 +291,7 @@ public class TextEditorTab extends JSplitPane {
 						+ "and shift+up/down arrow work like arrow keys before for caret movement\n"
 						+ "within a multi-line prompt."
 						;
-				JOptionPane.showMessageDialog(textEditor, msg, "REPL help", JOptionPane.INFORMATION_MESSAGE);
+				JOptionPane.showMessageDialog(textEditor, msg, "REPL Help", JOptionPane.INFORMATION_MESSAGE);
 			}
 		});
 		prompt_panel.add(prompt_help, bc);

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -103,6 +103,7 @@ public class TextEditorTab extends JSplitPane {
 					e.rejectDrop();
 					return;
 				}
+				e.acceptDrop(DnDConstants.ACTION_COPY_OR_MOVE); // fix for InvalidDnDOperationException: No drop current
 				Transferable t = e.getTransferable();
 				if (!t.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) return;
 				try {

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -261,16 +261,16 @@ public class TextEditorTab extends JSplitPane {
 		bc.gridx = 3;
 		final JButton prompt_help = new JButton("?");
 		prompt_help.addActionListener(a -> {
-			final String msg = "This REPL (read-evaluate-print-loop) parses " + textEditor.getCurrentLanguage().getLanguageName() + " code.\n\n"
+			final String msg = "This REPL (Read-Evaluate-Print-Loop) parses " + textEditor.getCurrentLanguage().getLanguageName() + " code.\n\n"
 					+ "Key bindings:\n"
-					+ "* enter: evaluate code\n"
-					+ "* shift+enter: add line break (also alt-enter and meta-enter)\n"
-					+ "* page UP or ctrl+p: show previous entry in the history\n"
-					+ "* page DOWN or ctrl+n: show next entry in the history\n"
+					+ "  [Enter]:   Evaluate code\n"
+					+ "  [Shift+Enter]:   Add line break (also alt-enter and meta-enter)\n"
+					+ "  [Page UP] or [Ctrl+P]:   Show previous entry in the history\n"
+					+ "  [Page DOWN] or [Ctrl+N]:   Show next entry in the history\n"
 					+ "\n"
-					+ "If 'Use arrow keys' is checked, then up/down arrows work like page UP/DOWN,\n"
-					+ "and shift+up/down arrow work like arrow keys before for caret movement\n"
-					+ "within a multi-line prompt."
+					+ "If 'Use arrow keys' is checked, then up/down arrows work like\n"
+					+ "Page UP/DOWN, and Shift+up/down arrows work like arrow\n"
+					+ "keys before for caret movement within a multi-line prompt."
 					;
 			JOptionPane.showMessageDialog(textEditor, msg, "REPL Help", JOptionPane.INFORMATION_MESSAGE);
 		});

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -79,6 +79,7 @@ public class TextEditorTab extends JSplitPane {
 	private final JButton runit, batchit, killit, toggleErrors, switchSplit;
 	private final JCheckBox incremental;
 	private final JSplitPane screenAndPromptSplit;
+	private int screenAndPromptSplitDividerLocation;
 
 	private final TextEditor textEditor;
 	private DropTarget dropTarget;
@@ -87,7 +88,10 @@ public class TextEditorTab extends JSplitPane {
 	public TextEditorTab(final TextEditor textEditor) {
 		super(JSplitPane.VERTICAL_SPLIT);
 		super.setResizeWeight(350.0 / 430.0);
-		this.setOneTouchExpandable(true);
+		// TF: disable setOneTouchExpandable() due to inconsistent behavior when
+		// applying preferences at startup. Also, it does not apply to all L&Fs.
+		// Users can use the controls in the menu bar to toggle the pane
+		this.setOneTouchExpandable(false);
 
 		this.textEditor = textEditor;
 		editorPane = new EditorPane();
@@ -210,7 +214,7 @@ public class TextEditorTab extends JSplitPane {
 				}
 				// Keep prompt collapsed if not in use
 				if (!incremental.isSelected()) {
-					SwingUtilities.invokeLater(() -> screenAndPromptSplit.setDividerLocation(1.0));
+					setREPLVisible(false);
 				}
 			}
 		});
@@ -299,7 +303,6 @@ public class TextEditorTab extends JSplitPane {
 		
 		super.setLeftComponent(editorPane.wrappedInScrollbars());
 		super.setRightComponent(screenAndPromptSplit);
-		screenAndPromptSplit.setDividerLocation(600);
 		screenAndPromptSplit.setDividerLocation(1.0);
 
 		// Persist Script Editor layout whenever split pane divider is adjusted.
@@ -312,6 +315,20 @@ public class TextEditorTab extends JSplitPane {
 	// Package-private
 	JSplitPane getScreenAndPromptSplit() {
 		return screenAndPromptSplit;
+	}
+
+	void setREPLVisible(final boolean visible) {
+		SwingUtilities.invokeLater(() -> {
+			if (visible) {
+				if (getScreenAndPromptSplit().getDividerLocation() <= getScreenAndPromptSplit().getMinimumDividerLocation())
+					getScreenAndPromptSplit().setDividerLocation(.5d); // half of panel's height
+				else
+					getScreenAndPromptSplit().setDividerLocation(screenAndPromptSplitDividerLocation);
+			} else { // collapse to bottom
+				screenAndPromptSplitDividerLocation = getScreenAndPromptSplit().getDividerLocation();
+				getScreenAndPromptSplit().setDividerLocation(1f);
+			}
+		});
 	}
 
 	@Override

--- a/src/main/java/org/scijava/ui/swing/script/commands/ChooseFontSize.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/ChooseFontSize.java
@@ -54,7 +54,7 @@ public class ChooseFontSize extends ContextCommand {
 		final float size = editor.getEditorPane().getFontSize();
 		changeFontSize(editor.getErrorScreen(), size);
 		changeFontSize(editor.getTab().getScreenInstance(), size);
-		editor.updateTabAndFontSize(false);
+		editor.updateUI(false);
 	}
 
 	private void changeFontSize(final JTextArea a, final float size) {

--- a/src/main/java/org/scijava/ui/swing/script/commands/ChooseTabSize.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/ChooseTabSize.java
@@ -54,7 +54,7 @@ public class ChooseTabSize extends DynamicCommand {
 	@Override
 	public void run() {
 		editor.getEditorPane().setTabSize(tabSize);
-		editor.updateTabAndFontSize(false);
+		editor.updateUI(false);
 	}
 
 	protected void initializeChoice() {


### PR DESCRIPTION
I've been using the editor these days quite a lot. One thing that use to  bonkers me all the time was the fact that font sizes were never consistently stored across restarts (e.g., the console would always have 12pt at startup). With a  hiDPI screen, I was always changing the fonts. So, I decided to finally cleanup all the hardwired values... 

At a certain point, it became obvious that we are not using RSyntaxArea to its full potential. One thing led to the other, and I ended up doing way more than what I had expected. Here is a summary:

- EditorPane:
  - Themes (!!), including a dark option
  - Tweaks using [RSyntaxTextArea](https://bobbylight.github.io/RSyntaxTextArea/)'s built-in options to recap the behavior of most IDEs:  Highlight occurrences of selected text; code folding with 'peek'  pop-up view over folded code, etc. Some of these are toggleable in the GUI
  - Reinstated bookmarks (were broken for many years): This allows to mark lines by clicking on the left gutter as in most IDEs
- Autocompletion:
  - There are now two fallbacks to handle unsupported languages:
    1. If no SciJava support exits, the editor will try to load support from RSyntaxTextArea's LanguageSupportFactory. Currently there is really nothing useful there for us, but the project remains quite [active](https://github.com/bobbylight/RSyntaxTextArea/releases), so this could change in the future (e.g., newer v3.1.6 supports Markdown and Kotlin)
        - @ctrueden, see https://github.com/scijava/pom-scijava/pull/191 for this
    3. If that did not work, there is now an option for using Java as 'fallback':  This tells the EditorPane to use Java as last resort. As you can imagine, this is a bit silly to say the least: it is pretty useless beyond static access to java.lang classes, but at least is _something_ more than nothing
  - When a language is chosen in the menu, the console displays the status and current settings of the auto-completion
  - Option for 'Auto-activation' (no need for Ctrl+Space), as per https://github.com/scijava/script-editor-jython/issues/8: 
    - @haesleinhuepf: RSyntaxArea supported this all along: Please test the new option: If it works well for you, I would suggest you disable your implementation. The preference is persistent and is on by default for backwards compatibility. (Those of us who dislike, we'll have to disable it and run 'Save Preferences', doing other-wise would break the status quo for IJ Macros)

- Other Improvements/Tweaks:
  - Opening of files by Drag & Drop: Dropping folders into the File Tree pane adds them there. Dropping files into the editor pane, opens them. For responsiveness, a confirmation prompt is shown when a large no. of files is involved
  - Options to toggle File Tree Pane, and Console
  - FileTree: Options for case-sensitive searches. Options to Expand/Collapse/Reveal in OS, etc. (contextual menu). Added a built-in help dialog with regex examples.
       - @cardona: there are two deviations from your implementation: Filter is case-insensitive by default, and the '/' trigger for Regex is now a checkbox, for consistency with the other options. Agree?
  - More consistent settings across restarts: Previous some preferences were not being stored or were being overwritten by hardwired values at startup
  - Filename tabs: Can be moved to any side of the window, and are navigable using scroll-wheel
  - Organized menus. Find and Replace are now aggregated into a single menu entry.
  - The new Help menu includes links to online resources
  - Line numbers in gutter are always scaled proportionally

@ctrueden  I felt easier to add this [class](https://github.com/scijava/script-editor/blob/ac1c86080ef745025ecedba900393c0dbe417c11/src/main/java/org/scijava/ui/swing/script/FileDrop.java) that implements the File Drag&Drop. it is in the public domain. It works quite well (SNT uses it _a lot_). Would be super useful to add it to all the scijava Swing-based components that handle files (e.g., file prompts)

@imagejan, @ctrueden, @haesleinhuepf, @acardona: Unfortunately, I won't have time to do much more. Would be great if you guys could test things on your end. The Editor is getting better and better all the time!!

I am attaching a binary here, in case it helps (note the dummy .zip extension appended to fool the uploader). 
[script-editor-0.6.2-SNAPSHOT.jar.zip](https://github.com/scijava/script-editor/files/8134338/script-editor-0.6.2-SNAPSHOT.jar.zip)

Also, here are some snapshots:

![image](https://user-images.githubusercontent.com/2439948/155571077-d6c8b376-c4cf-4aa3-bf86-a9ae7c259169.png)

![image](https://user-images.githubusercontent.com/2439948/155571008-fdaee8f5-3bd5-415e-9b5c-393f83290440.png)

![image](https://user-images.githubusercontent.com/2439948/155570653-e442c906-6954-4a49-9954-fcdfe00b52e8.png)



