### PR TITLE
Command Palette, Kotlin and Markdown syntaxes and other features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,10 +164,12 @@
 		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>rsyntaxtextarea</artifactId>
+			<version>3.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fifesoft</groupId>
 			<artifactId>languagesupport</artifactId>
+			<version>3.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.miglayout</groupId>
@@ -198,6 +200,10 @@
 			<groupId>org.scijava</groupId>
 			<artifactId>scripting-groovy</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.formdev</groupId>
+			<artifactId>flatlaf</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/scijava/ui/swing/script/CommandPalette.java
+++ b/src/main/java/org/scijava/ui/swing/script/CommandPalette.java
@@ -1,0 +1,844 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2022 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package org.scijava.ui.swing.script;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+
+import javax.swing.AbstractAction;
+import javax.swing.AbstractButton;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JRootPane;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.ListSelectionModel;
+import javax.swing.MenuElement;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+
+import org.scijava.util.PlatformUtils;
+
+class CommandPalette {
+
+	private static final String NAME = "Command Palette...";
+
+	/** Settings. Ought to become adjustable some day */
+	private static final KeyStroke ACCELERATOR = KeyStroke.getKeyStroke(KeyEvent.VK_P,
+			java.awt.Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK);
+	private static final int TABLE_ROWS = 6; // no. of commands to be displayed
+	private static final float OPACITY = 1f; // 0-1 range
+	private static final boolean IGNORE_WHITESPACE = true; // Ignore white spaces while matching?
+	private static Palette frame;
+
+	private SearchField searchField;
+	private CmdTable table;
+	private final TextEditor textEditor;
+	private final CmdAction noHitsCmd;
+	private final CmdScrapper cmdScrapper;
+
+	public CommandPalette(final TextEditor textEditor) {
+		this.textEditor = textEditor;
+		noHitsCmd = new SearchWebCmd();
+		cmdScrapper = new CmdScrapper(textEditor);
+	}
+
+	void register(final JMenu toolsMenu) {
+		final Action action = new AbstractAction(NAME) {
+
+			private static final long serialVersionUID = -7030359886427866104L;
+
+			@Override
+			public void actionPerformed(final ActionEvent e) {
+				toggleVisibility();
+			}
+
+		};
+		action.putValue(Action.ACCELERATOR_KEY, ACCELERATOR);
+		toolsMenu.add(new JMenuItem(action));
+	}
+
+	void dispose() {
+		if (frame != null)
+			frame.dispose();
+		frame = null;
+	}
+
+	private void hideWindow() {
+		if (frame != null)
+			frame.setVisible(false);
+	}
+
+	private void assemblePalette() {
+		if (frame != null)
+			return;
+		frame = new Palette();
+		final Container contentPane = frame.getContentPane();
+		contentPane.setLayout(new BorderLayout());
+		searchField = new SearchField();
+		contentPane.add(searchField, BorderLayout.NORTH);
+		searchField.getDocument().addDocumentListener(new PromptDocumentListener());
+		final InternalKeyListener keyListener = new InternalKeyListener();
+		searchField.addKeyListener(keyListener);
+		table = new CmdTable();
+		table.addKeyListener(keyListener);
+		table.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(final MouseEvent e) {
+				if (e.getClickCount() == 2 && table.getSelectedRow() > -1) {
+					runCmd(table.getInternalModel().getCommand(table.getSelectedRow()));
+				}
+			}
+		});
+		contentPane.add(table.getScrollPane(), BorderLayout.CENTER);
+		populateList("");
+		frame.pack();
+	}
+
+	private String[] makeRow(final String command, final CmdAction ca) {
+		final String[] result = new String[table.getColumnCount()];
+		result[0] = command;
+		result[1] = ca.description();
+		return result;
+	}
+
+	private void populateList(final String matchingSubstring) {
+		final ArrayList<String[]> list = new ArrayList<>();
+		if (!cmdScrapper.scrapeSuccessful())
+			cmdScrapper.scrape();
+		cmdScrapper.getCmdMap().forEach((id, cmd) -> {
+			if (cmd.matches(matchingSubstring)) {
+				list.add(makeRow(id, cmd));
+			}
+		});
+		if (list.isEmpty()) {
+			list.add(makeRow(noHitsCmd.id, noHitsCmd));
+		}
+		table.getInternalModel().setData(list);
+		if (searchField != null)
+			searchField.requestFocus();
+	}
+
+	private void runCmd(final String command) {
+		final CmdAction cmd;
+		hideWindow(); // hide before running, in case command opens a dialog
+		if (noHitsCmd != null && command.equals(noHitsCmd.id)) {
+			cmd = noHitsCmd;
+		} else {
+			cmd = cmdScrapper.getCmdMap().get(command);
+		}
+		if (cmd != null) {
+			if (cmd.button != null) {
+				cmd.button.doClick();
+			} else if (cmd.action != null) {
+				cmd.action.actionPerformed(
+						new ActionEvent(textEditor.getTextArea(), ActionEvent.ACTION_PERFORMED, cmd.id));
+			}
+		}
+	}
+
+	private void toggleVisibility() {
+		if (frame == null) {
+			assemblePalette();
+		}
+		if (frame.isVisible()) {
+			hideWindow();
+		} else {
+			frame.center(textEditor);
+			table.clearSelection();
+			frame.setVisible(true);
+			searchField.requestFocus();
+		}
+	}
+
+	private static List<JMenuItem> getMenuItems(final JPopupMenu popupMenu) {
+		final List<JMenuItem> list = new ArrayList<>();
+		for (final MenuElement me : popupMenu.getSubElements()) {
+			if (me == null) {
+				continue;
+			} else if (me instanceof JMenuItem) {
+				list.add((JMenuItem) me);
+			} else if (me instanceof JMenu) {
+				getMenuItems((JMenu) me, list);
+			}
+		}
+		return list;
+	}
+
+	private static void getMenuItems(final JMenu menu, final List<JMenuItem> holdingList) {
+		for (int j = 0; j < menu.getItemCount(); j++) {
+			final JMenuItem jmi = menu.getItem(j);
+			if (jmi == null)
+				continue;
+			if (jmi instanceof JMenu) {
+				getMenuItems((JMenu) jmi, holdingList);
+			} else {
+				holdingList.add(jmi);
+			}
+		}
+	}
+
+	private static class SearchField extends TextEditor.TextFieldWithPlaceholder {
+		private static final long serialVersionUID = 1L;
+		private static final int PADDING = 4;
+		static final Font REF_FONT = refFont();
+
+		SearchField() {
+			super(" Search for commands and actions (e.g., Theme)");
+			setMargin(new Insets(PADDING, PADDING, 0, 0));
+			setFont(REF_FONT.deriveFont(REF_FONT.getSize() * 1.5f));
+		}
+
+		@Override
+		Font getPlaceholderFont() {
+			return REF_FONT.deriveFont(Font.ITALIC);
+		}
+
+		static Font refFont() {
+			try {
+				return UIManager.getFont("TextField.font");
+			} catch (final Exception ignored) {
+				return new JTextField().getFont();
+			}
+		}
+	}
+
+	private class PromptDocumentListener implements DocumentListener {
+		public void insertUpdate(final DocumentEvent e) {
+			populateList(getQueryFromSearchField());
+		}
+
+		public void removeUpdate(final DocumentEvent e) {
+			populateList(getQueryFromSearchField());
+		}
+
+		public void changedUpdate(final DocumentEvent e) {
+			populateList(getQueryFromSearchField());
+		}
+
+		String getQueryFromSearchField() {
+			final String text = searchField.getText();
+			if (text == null)
+				return "";
+			final String query = text.toLowerCase();
+			return (IGNORE_WHITESPACE) ? query.replaceAll("\\s+", "") : query;
+		}
+	}
+
+	private class InternalKeyListener extends KeyAdapter {
+
+		@Override
+		public void keyPressed(final KeyEvent ke) {
+			final int key = ke.getKeyCode();
+			final int flags = ke.getModifiersEx();
+			final int items = table.getInternalModel().getRowCount();
+			final Object source = ke.getSource();
+			final boolean meta = ((flags & KeyEvent.META_DOWN_MASK) != 0) || ((flags & KeyEvent.CTRL_DOWN_MASK) != 0);
+			if (key == KeyEvent.VK_ESCAPE || (key == KeyEvent.VK_W && meta) || (key == KeyEvent.VK_P && meta)) {
+				hideWindow();
+			} else if (source == searchField) {
+				/*
+				 * If you hit enter in the text field, and there's only one command that
+				 * matches, run that:
+				 */
+				if (key == KeyEvent.VK_ENTER) {
+					if (1 == items)
+						runCmd(table.getInternalModel().getCommand(0));
+				}
+				/*
+				 * If you hit the up or down arrows in the text field, move the focus to the
+				 * table and select the row at the bottom or top.
+				 */
+				int index = -1;
+				if (key == KeyEvent.VK_UP) {
+					index = table.getSelectedRow() - 1;
+					if (index < 0)
+						index = items - 1;
+				} else if (key == KeyEvent.VK_DOWN) {
+					index = table.getSelectedRow() + 1;
+					if (index >= items)
+						index = Math.min(items - 1, 0);
+				}
+				if (index >= 0) {
+					table.requestFocus();
+					// completions.ensureIndexIsVisible(index);
+					table.setRowSelectionInterval(index, index);
+				}
+			} else if (key == KeyEvent.VK_BACK_SPACE || key == KeyEvent.VK_DELETE) {
+				/*
+				 * If someone presses backspace or delete they probably want to remove the last
+				 * letter from the search string, so switch the focus back to the prompt:
+				 */
+				searchField.requestFocus();
+			} else if (source == table) {
+				/* If you hit enter with the focus in the table, run the selected command */
+				if (key == KeyEvent.VK_ENTER) {
+					ke.consume();
+					final int row = table.getSelectedRow();
+					if (row >= 0)
+						runCmd(table.getInternalModel().getCommand(row));
+					/* Loop through the list using the arrow keys */
+				} else if (key == KeyEvent.VK_UP) {
+					if (table.getSelectedRow() == 0)
+						table.setRowSelectionInterval(table.getRowCount() - 1, table.getRowCount() - 1);
+				} else if (key == KeyEvent.VK_DOWN) {
+					if (table.getSelectedRow() == table.getRowCount() - 1)
+						table.setRowSelectionInterval(0, 0);
+				}
+			}
+		}
+	}
+
+	private class Palette extends JFrame {
+		private static final long serialVersionUID = 1L;
+
+		Palette() {
+			super("Command Palette");
+			setUndecorated(true);
+			setAlwaysOnTop(true);
+			setOpacity(OPACITY);
+			getRootPane().setWindowDecorationStyle(JRootPane.NONE);
+			// it should NOT be possible to minimize this frame, but just to
+			// be safe, we'll ensure the frame is never in an awkward state
+			addWindowListener(new WindowAdapter() {
+				@Override
+				public void windowClosing(final WindowEvent e) {
+					hideWindow();
+				}
+
+				@Override
+				public void windowIconified(final WindowEvent e) {
+					hideWindow();
+				}
+
+				@Override
+				public void windowDeactivated(final WindowEvent e) {
+					hideWindow();
+				}
+			});
+		}
+
+		void center(final Container component) {
+			final Rectangle bounds = component.getBounds();
+			final Dimension w = getSize();
+			int x = bounds.x + (bounds.width - w.width) / 2;
+			int y = bounds.y + (bounds.height - w.height) / 2;
+			if (x < 0)
+				x = 0;
+			if (y < 0)
+				y = 0;
+			setLocation(x, y);
+		}
+	}
+
+	private class CmdTable extends JTable {
+		private static final long serialVersionUID = 1L;
+
+		CmdTable() {
+			super(new CmdTableModel());
+			setAutoCreateRowSorter(false);
+			setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+			setShowGrid(false);
+			setRowSelectionAllowed(true);
+			setColumnSelectionAllowed(false);
+			setTableHeader(null);
+			setAutoResizeMode(AUTO_RESIZE_LAST_COLUMN);
+			final CmdTableRenderer renderer = new CmdTableRenderer();
+			final int col0Width = renderer.maxWidh(0);
+			final int col1Width = renderer.maxWidh(1);
+			setDefaultRenderer(Object.class, renderer);
+			getColumnModel().getColumn(0).setMaxWidth(col0Width);
+			getColumnModel().getColumn(1).setMaxWidth(col1Width);
+			setRowHeight(renderer.rowHeight());
+			final int height = TABLE_ROWS * getRowMargin() * getRowHeight();
+			setPreferredScrollableViewportSize(new Dimension(col0Width + col1Width, height));
+		}
+
+		private JScrollPane getScrollPane() {
+			final JScrollPane scrollPane = new JScrollPane(this, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+					JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+			scrollPane.setWheelScrollingEnabled(true);
+			return scrollPane;
+		}
+
+		CmdTableModel getInternalModel() {
+			return (CmdTableModel) getModel();
+		}
+
+	}
+
+	private class CmdTableRenderer extends DefaultTableCellRenderer {
+
+		private static final long serialVersionUID = 1L;
+		final Font col0Font = SearchField.REF_FONT.deriveFont(SearchField.REF_FONT.getSize() * 1.2f);
+		final Font col1Font = SearchField.REF_FONT.deriveFont(SearchField.REF_FONT.getSize() * 1.2f);
+
+		public Component getTableCellRendererComponent(final JTable table, final Object value, final boolean isSelected,
+				final boolean hasFocus, final int row, final int column) {
+			final Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+			if (column == 1) {
+				setHorizontalAlignment(JLabel.RIGHT);
+				setEnabled(false);
+				setFont(col1Font);
+			} else {
+				setHorizontalAlignment(JLabel.LEFT);
+				setEnabled(true);
+				setFont(col0Font);
+			}
+			return c;
+		}
+
+		int rowHeight() {
+			return (int) (col0Font.getSize() * 1.75f);
+		}
+
+		int maxWidh(final int columnIndex) {
+			if (columnIndex == 1)
+				return SwingUtilities.computeStringWidth(getFontMetrics(col1Font), "Really+Huge+Key+Combo");
+			return SwingUtilities.computeStringWidth(getFontMetrics(col0Font),
+					"A large filename from the Recents menu.groovy");
+		}
+
+	}
+
+	private class CmdTableModel extends AbstractTableModel {
+		private static final long serialVersionUID = 1L;
+		private final static int COLUMNS = 2;
+		List<String[]> list;
+
+		void setData(final ArrayList<String[]> list) {
+			this.list = list;
+			fireTableDataChanged();
+		}
+
+		String getCommand(final int row) {
+			if (list.size() == 1)
+				return (String) getValueAt(row, 0);
+			else if (row < 0 || row >= list.size())
+				return "";
+			else
+				return (String) getValueAt(row, 0);
+		}
+
+		@Override
+		public int getColumnCount() {
+			return COLUMNS;
+		}
+
+		@Override
+		public Object getValueAt(final int row, final int column) {
+			if (row >= list.size() || column >= COLUMNS)
+				return null;
+			final String[] strings = (String[]) list.get(row);
+			return strings[column];
+		}
+
+		@Override
+		public int getRowCount() {
+			return list.size();
+		}
+
+	}
+
+	private class CmdAction {
+
+		final String id;
+		String menuLocation;
+		String hotkey;
+		AbstractButton button;
+		AbstractAction action;
+
+		CmdAction(final String cmdName) {
+			this.id = capitalize(cmdName);
+			this.menuLocation = "";
+			this.hotkey = "";
+		}
+
+		CmdAction(final String cmdName, final AbstractButton button) {
+			this(cmdName);
+			if (button.getAction() != null && button.getAction() instanceof AbstractAction)
+				action = (AbstractAction) button.getAction();
+			else
+				this.button = button;
+		}
+
+		CmdAction(final String cmdName, final AbstractAction action) {
+			this(cmdName);
+			this.action = action;
+		}
+
+		String description() {
+			return (hotkey.isEmpty()) ? "|" + menuLocation + "|" : hotkey;
+		}
+
+		boolean matches(final String lowercaseQuery) {
+			if (IGNORE_WHITESPACE) {
+				return id.toLowerCase().replaceAll("\\s+", "").contains(lowercaseQuery)
+						|| menuLocation.toLowerCase().contains(lowercaseQuery);
+			}
+			return id.toLowerCase().contains(lowercaseQuery) || menuLocation.toLowerCase().contains(lowercaseQuery);
+		}
+
+		void setkeyString(final KeyStroke key) {
+			hotkey = prettifiedKey(key);
+		}
+
+		private String capitalize(final String string) {
+			return string.substring(0, 1).toUpperCase() + string.substring(1);
+		}
+
+		private String prettifiedKey(final KeyStroke key) {
+			if (key == null)
+				return "";
+			final StringBuilder s = new StringBuilder();
+			final int m = key.getModifiers();
+			if ((m & InputEvent.CTRL_DOWN_MASK) != 0) {
+				s.append("Ctrl ");
+			}
+			if ((m & InputEvent.META_DOWN_MASK) != 0) {
+				s.append((PlatformUtils.isMac()) ? "⌘ " : "Ctrl ");
+			}
+			if ((m & InputEvent.ALT_DOWN_MASK) != 0) {
+				s.append("Alt ");
+			}
+			if ((m & InputEvent.SHIFT_DOWN_MASK) != 0) {
+				s.append("Shift ");
+			}
+			if ((m & InputEvent.BUTTON1_DOWN_MASK) != 0) {
+				s.append("L-click ");
+			}
+			if ((m & InputEvent.BUTTON2_DOWN_MASK) != 0) {
+				s.append("R-click ");
+			}
+			if ((m & InputEvent.BUTTON3_DOWN_MASK) != 0) {
+				s.append("M-click ");
+			}
+			switch (key.getKeyEventType()) {
+			case KeyEvent.KEY_TYPED:
+				s.append(key.getKeyChar() + " ");
+				break;
+			case KeyEvent.KEY_PRESSED:
+			case KeyEvent.KEY_RELEASED:
+				s.append(getKeyText(key.getKeyCode()) + " ");
+				break;
+			default:
+				break;
+			}
+			return s.toString();
+		}
+
+		String getKeyText(final int keyCode) {
+			if (keyCode >= KeyEvent.VK_0 && keyCode <= KeyEvent.VK_9
+					|| keyCode >= KeyEvent.VK_A && keyCode <= KeyEvent.VK_Z) {
+				return String.valueOf((char) keyCode);
+			}
+			switch (keyCode) {
+			case KeyEvent.VK_COMMA:
+				return ",";
+			case KeyEvent.VK_PERIOD:
+				return ".";
+			case KeyEvent.VK_SLASH:
+				return "/";
+			case KeyEvent.VK_SEMICOLON:
+				return ";";
+			case KeyEvent.VK_EQUALS:
+				return "=";
+			case KeyEvent.VK_OPEN_BRACKET:
+				return "[";
+			case KeyEvent.VK_BACK_SLASH:
+				return "\\";
+			case KeyEvent.VK_CLOSE_BRACKET:
+				return "]";
+			case KeyEvent.VK_ENTER:
+				return "↵";
+			case KeyEvent.VK_BACK_SPACE:
+				return "⌫";
+			case KeyEvent.VK_TAB:
+				return "↹";
+			case KeyEvent.VK_CANCEL:
+				return "Cancel";
+			case KeyEvent.VK_CLEAR:
+				return "Clear";
+			case KeyEvent.VK_PAUSE:
+				return "Pause";
+			case KeyEvent.VK_CAPS_LOCK:
+				return "Caps Lock";
+			case KeyEvent.VK_ESCAPE:
+				return "Esc";
+			case KeyEvent.VK_SPACE:
+				return "Space";
+			case KeyEvent.VK_PAGE_UP:
+				return "⇞";
+			case KeyEvent.VK_PAGE_DOWN:
+				return "⇟";
+			case KeyEvent.VK_END:
+				return "END";
+			case KeyEvent.VK_HOME:
+				return "Home"; // "⌂";
+			case KeyEvent.VK_LEFT:
+				return "←";
+			case KeyEvent.VK_UP:
+				return "↑";
+			case KeyEvent.VK_RIGHT:
+				return "→";
+			case KeyEvent.VK_DOWN:
+				return "↓";
+			case KeyEvent.VK_MULTIPLY:
+				return "[Num ×]";
+			case KeyEvent.VK_ADD:
+				return "[Num +]";
+			case KeyEvent.VK_SUBTRACT:
+				return "[Num -]";
+			case KeyEvent.VK_DIVIDE:
+				return "[Num /]";
+			case KeyEvent.VK_DELETE:
+				return "⌦";
+			case KeyEvent.VK_INSERT:
+				return "Ins";
+			case KeyEvent.VK_BACK_QUOTE:
+				return "BACK_QUOTE";
+			case KeyEvent.VK_QUOTE:
+				return "[']";
+			case KeyEvent.VK_AMPERSAND:
+				return "[&]";
+			case KeyEvent.VK_ASTERISK:
+				return "[*]";
+			case KeyEvent.VK_QUOTEDBL:
+				return "[\"]";
+			case KeyEvent.VK_LESS:
+				return "[<]";
+			case KeyEvent.VK_GREATER:
+				return "[>]";
+			case KeyEvent.VK_BRACELEFT:
+				return "{";
+			case KeyEvent.VK_BRACERIGHT:
+				return "}";
+			case KeyEvent.VK_COLON:
+				return ",";
+			case KeyEvent.VK_CIRCUMFLEX:
+				return "^";
+			case KeyEvent.VK_DEAD_TILDE:
+				return "~";
+			case KeyEvent.VK_DOLLAR:
+				return "$";
+			case KeyEvent.VK_EXCLAMATION_MARK:
+				return "!";
+			case KeyEvent.VK_LEFT_PARENTHESIS:
+				return "(";
+			case KeyEvent.VK_MINUS:
+				return "[-]";
+			case KeyEvent.VK_PLUS:
+				return "[+]";
+			case KeyEvent.VK_RIGHT_PARENTHESIS:
+				return ")";
+			case KeyEvent.VK_UNDERSCORE:
+				return "_";
+			default:
+				return KeyEvent.getKeyText(keyCode);
+			}
+		}
+	}
+
+	private class CmdScrapper {
+		final TextEditor textEditor;
+		private final TreeMap<String, CmdAction> cmdMap;
+
+		CmdScrapper(final TextEditor textEditor) {
+			this.textEditor = textEditor;
+			// It seems that the ScriptEditor has duplicated actions(!?) registered
+			// in input/action maps. Some Duplicates seem to be defined in lower
+			// case, so we'll assemble a case-insensitive map to mitigate this
+			cmdMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+		}
+
+		TreeMap<String, CmdAction> getCmdMap() {
+			return cmdMap;
+		}
+
+		boolean scrapeSuccessful() {
+			return !cmdMap.isEmpty();
+		}
+
+		void scrape() {
+			cmdMap.clear();
+			final JMenuBar menuBar = textEditor.getJMenuBar();
+			final int topLevelMenus = menuBar.getMenuCount();
+			for (int i = 0; i < topLevelMenus; ++i) {
+				final JMenu topLevelMenu = menuBar.getMenu(i);
+				if (topLevelMenu != null && topLevelMenu.getText() != null) {
+					parseMenu(topLevelMenu.getText(), topLevelMenu);
+				}
+			}
+			final JPopupMenu popup = textEditor.getEditorPane().getPopupMenu();
+			if (popup != null) {
+				getMenuItems(popup).forEach(mi -> {
+					registerMenuItem(mi, "Popup");
+				});
+			}
+			parseMaps();
+		}
+
+		private void parseMaps() {
+			final InputMap inputMap = textEditor.getTextArea().getInputMap(JComponent.WHEN_FOCUSED);
+			final ActionMap actionMap = textEditor.getTextArea().getActionMap();
+			final KeyStroke[] keys = inputMap.allKeys();
+			if (keys != null) {
+				for (final KeyStroke key : keys) {
+					if (key.getModifiers() == 0) {
+						// ignore 'typed' keystrokes and related single-key actions
+						continue;
+					}
+					final Object obj = inputMap.get(key);
+					CmdAction cmdAction;
+					String cmdName;
+					if (obj instanceof AbstractAction) {
+						cmdName = (String) ((AbstractAction) obj).getValue(Action.NAME);
+						cmdAction = new CmdAction(cleanseActionDescription(cmdName), (AbstractAction) obj);
+					} else if (obj instanceof AbstractButton) {
+						cmdName = ((AbstractButton) obj).getText();
+						cmdAction = new CmdAction(cmdName, (AbstractButton) obj);
+					} else if (obj instanceof String) {
+						final Action action = actionMap.get((String) obj);
+						cmdAction = new CmdAction(cleanseActionDescription((String) obj), (AbstractAction) action);
+					} else {
+						continue;
+					}
+					cmdAction.setkeyString(key);
+					cmdMap.put(cmdAction.id, cmdAction);
+				}
+			}
+		}
+
+		private void parseMenu(final String componentHostingMenu, final JMenu menu) {
+			final int n = menu.getItemCount();
+			for (int i = 0; i < n; ++i) {
+				registerMenuItem(menu.getItem(i), componentHostingMenu);
+			}
+		}
+
+		private void registerMenuItem(final JMenuItem m, final String hostingComponent) {
+			if (m != null && m.isEnabled()) {
+				String label = m.getActionCommand();
+				if (label == null)
+					label = m.getText();
+				if (m instanceof JMenu) {
+					final JMenu subMenu = (JMenu) m;
+					String hostDesc = subMenu.getText();
+					if (hostDesc == null)
+						hostDesc = hostingComponent;
+					parseMenu(hostDesc, subMenu);
+				} else {
+					register(m, hostingComponent);
+				}
+			}
+		}
+
+		private boolean irrelevantCommand(final String label) {
+			// commands that would only add clutter to the palette
+			return label == null || label.endsWith(" pt") || label.length() < 2;
+		}
+
+		private void register(final AbstractButton button, final String descriptionOfComponentHostingButton) {
+			String label = button.getActionCommand();
+			if (NAME.equals(label))
+				return; // do not register command palette
+			if (label == null)
+				label = button.getText().trim();
+			if (irrelevantCommand(label))
+				return;
+			if (label.endsWith("..."))
+				label = label.substring(0, label.length() - 3);
+			CmdAction ca = (CmdAction) cmdMap.get(label);
+			if (ca == null) {
+				ca = new CmdAction(label, button);
+				ca.menuLocation = descriptionOfComponentHostingButton;
+				if (button instanceof JMenuItem) {
+					ca.setkeyString(((JMenuItem) button).getAccelerator());
+				}
+				cmdMap.put(ca.id, ca);
+			}
+			// else command label is not unique. Hopefully, this won't happen often
+		}
+
+		private String cleanseActionDescription(String actionId) {
+			if (actionId.startsWith("RTA."))
+				actionId = actionId.substring(4);
+			else if (actionId.startsWith("RSTA."))
+				actionId = actionId.substring(5);
+			if (actionId.endsWith("Action"))
+				actionId = actionId.substring(0, actionId.length() - 6);
+			actionId = actionId.replace("-", " ");
+			return actionId.replaceAll("([A-Z])", " $1").trim(); // CamelCase to Camel Case
+		}
+	}
+
+	private class SearchWebCmd extends CmdAction {
+		SearchWebCmd() {
+			super("Search the Web");
+			button = new JMenuItem(new AbstractAction(id) {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public void actionPerformed(final ActionEvent e) {
+					TextEditor.GuiUtils.runSearchQueryInBrowser(textEditor, textEditor.getPlatformService(),
+							searchField.getText());
+				}
+			});
+		}
+
+		@Override
+		String description() {
+			return "|Unmatched action|";
+		}
+	}
+}

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -324,17 +324,20 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	private JMenuItem getSyntaxItem(final ButtonGroup bg, final String label, final String syntaxId) {
 		final JRadioButtonMenuItem item = new JRadioButtonMenuItem(label);
 		bg.add(item);
-		item.setActionCommand(syntaxId);
 		item.addActionListener(e -> {
 			if (getCurrentLanguage() == null) {
 				setSyntaxEditingStyle(syntaxId);
 			} else {
-				log.error("[BUG] Unknown state: Non-executable syntaxes cannot be applied to valid languages");
+				error("Non-executable syntaxes can only be applied when scripting language is 'None'.");
 				bg.getElements().nextElement().setSelected(true); //select none
 				setSyntaxEditingStyle(SYNTAX_STYLE_NONE);
 			}
 		});
 		return item;
+	}
+
+	void error(final String message) {
+		JOptionPane.showMessageDialog(this, message, "Error", JOptionPane.ERROR_MESSAGE);
 	}
 
 	private void updateNoneLangSyntaxMenu(final ScriptLanguage language) {

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -56,7 +56,6 @@ import javax.swing.Action;
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JScrollPane;
@@ -314,7 +313,9 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		menu.add(getSyntaxItem(bg, "Dockerfile", SYNTAX_STYLE_DOCKERFILE));
 		menu.add(getSyntaxItem(bg, "HTML", SYNTAX_STYLE_HTML));
 		menu.add(getSyntaxItem(bg, "JSON", SYNTAX_STYLE_JSON));
+		menu.add(getSyntaxItem(bg, "Kotlin", SYNTAX_STYLE_KOTLIN));
 		menu.add(getSyntaxItem(bg, "Makefile", SYNTAX_STYLE_MAKEFILE));
+		menu.add(getSyntaxItem(bg, "Markdown", SYNTAX_STYLE_MARKDOWN));
 		menu.add(getSyntaxItem(bg, "SH", SYNTAX_STYLE_UNIX_SHELL));
 		menu.add(getSyntaxItem(bg, "XML", SYNTAX_STYLE_XML));
 		menu.add(getSyntaxItem(bg, "YAML", SYNTAX_STYLE_YAML));
@@ -337,7 +338,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	}
 
 	void error(final String message) {
-		JOptionPane.showMessageDialog(this, message, "Error", JOptionPane.ERROR_MESSAGE);
+		TextEditor.GuiUtils.error(this, message);
 	}
 
 	private void updateNoneLangSyntaxMenu(final ScriptLanguage language) {
@@ -948,8 +949,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			}
 			catch (final BadLocationException e) {
 				/* ignore */
-				JOptionPane.showMessageDialog(this, "Cannot toggle bookmark at this location.", "Error",
-						JOptionPane.ERROR_MESSAGE);
+				error("Cannot toggle bookmark at this location.");
 			}
 		}
 	}
@@ -1099,7 +1099,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 	 */
 	public void applyTheme(final String theme) throws IllegalArgumentException {
 		try {
-			applyTheme(getTheme(theme));
+			applyTheme(TextEditor.getTheme(theme));
 		} catch (final Exception ex) {
 			throw new IllegalArgumentException(ex);
 		}
@@ -1115,15 +1115,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		th.apply(this);
 		setFontSize(existingFontSize);
 		GutterUtils.updateIcons(gutter);
-	}
-
-	private static Theme getTheme(final String theme) throws IllegalArgumentException {
-		try {
-			return Theme
-					.load(TextEditor.class.getResourceAsStream("/org/fife/ui/rsyntaxtextarea/themes/" + theme + ".xml"));
-		} catch (final Exception ex) {
-			throw new IllegalArgumentException(ex);
-		}
 	}
 
 	public String loadFolders() {

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -1192,8 +1192,7 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			if (selection == null) {
 				UIManager.getLookAndFeel().provideErrorFeedback(textArea);
 			} else {
-				final String link = "https://duckduckgo.com/?q=" + selection.trim().replace(" ", "+");
-				openLinkInBrowser(link);
+				TextEditor.GuiUtils.runSearchQueryInBrowser(EditorPane.this, platformService, selection.trim());
 			}
 			textArea.requestFocusInWindow();
 		}
@@ -1208,8 +1207,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 			jmi.setText("Search Web for Selection");
 			return jmi;
 		}
-
-
 	}
 
 	class OpenLinkUnderCursor extends RecordableTextAction {

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -288,15 +288,6 @@ public class EditorPane extends RSyntaxTextArea implements DocumentListener {
 		final Action action = getActionMap().get(actionID);
 		final JMenuItem jmi = new JMenuItem(action);
 		jmi.setAccelerator(getPaneActions().getAccelerator(actionID));
-		jmi.addActionListener(e -> {
-			if (editingAction && isLocked()) {
-				UIManager.getLookAndFeel().provideErrorFeedback(this);
-			} else try {
-				action.actionPerformed(e);
-			} catch (final Exception | Error ex) {
-				log.debug(ex);
-			}
-		});
 		jmi.setText(label);
 		return jmi;
 	}

--- a/src/main/java/org/scijava/ui/swing/script/FileFunctions.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileFunctions.java
@@ -93,13 +93,14 @@ public class FileFunctions {
 		final File baseDirectory = new File(workspace, baseName);
 
 		final List<String> result = new ArrayList<>();
-		final JarFile jar = new JarFile(path);
-		for (final JarEntry entry : Collections.list(jar.entries())) {
-			final String name = entry.getName();
-			if (name.endsWith(".class") || name.endsWith("/")) continue;
-			final String destination = baseDirectory + name;
-			copyTo(jar.getInputStream(entry), destination);
-			result.add(destination);
+		try (JarFile jar = new JarFile(path)) {
+			for (final JarEntry entry : Collections.list(jar.entries())) {
+				final String name = entry.getName();
+				if (name.endsWith(".class") || name.endsWith("/")) continue;
+				final String destination = baseDirectory + name;
+				copyTo(jar.getInputStream(entry), destination);
+				result.add(destination);
+			}
 		}
 		return result;
 	}
@@ -223,7 +224,7 @@ public class FileFunctions {
 		}
 		if (paths.size() == 1) return new File(workspace, paths.get(0))
 			.getAbsolutePath();
-		final String[] names = paths.toArray(new String[paths.size()]);
+		//final String[] names = paths.toArray(new String[paths.size()]);
 		final JFileChooser chooser = new JFileChooser(workspace);
 		chooser.setDialogTitle("Choose path");
 		if (chooser.showOpenDialog(parent) != JFileChooser.APPROVE_OPTION) return null;
@@ -304,8 +305,7 @@ public class FileFunctions {
 			final String prefix = url.substring(bang + 2);
 			final int prefixLength = prefix.length();
 
-			try {
-				final JarFile jar = new JarFile(jarURL);
+			try (JarFile jar = new JarFile(jarURL)) {
 				final Enumeration<JarEntry> e = jar.entries();
 				while (e.hasMoreElements()) {
 					final JarEntry entry = e.nextElement();
@@ -504,11 +504,11 @@ public class FileFunctions {
 		final int line)
 	{
 		if (file == null || gitDirectory == null) {
-			error("No file or git directory");
+			parent.error("No file or git directory.");
 			return;
 		}
 		final String url = getGitwebURL(file, gitDirectory, line);
-		if (url == null) error("Could not get gitweb URL for " + file);
+		if (url == null) parent.error("Could not get gitweb URL for " + file + ".");
 		else try {
 			parent.getPlatformService().open(new URL(url));
 		}
@@ -597,11 +597,6 @@ public class FileFunctions {
 		if (string.endsWith(suffix)) return string.substring(0, string.length() -
 			suffix.length());
 		return string;
-	}
-
-	protected boolean error(final String message) {
-		JOptionPane.showMessageDialog(parent, message);
-		return false;
 	}
 
 	/**

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
@@ -32,13 +32,10 @@ package org.scijava.ui.swing.script;
 import java.awt.Color;
 import java.awt.Desktop;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.FontMetrics;
-import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.RenderingHints;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.event.KeyAdapter;
@@ -53,7 +50,6 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import javax.swing.BorderFactory;
-import javax.swing.FocusManager;
 import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFileChooser;
@@ -62,7 +58,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
-import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
@@ -199,7 +194,7 @@ class FileSystemTreePanel extends JPanel {
 		return field;
 	}
 
-	private JButton thinButton(final String label) {
+	private JButton thinButton(final String label, final float factor) {
 		final JButton b = new JButton(label);
 		try {
 			if ("com.apple.laf.AquaLookAndFeel".equals(UIManager.getLookAndFeel().getClass().getName())) {
@@ -209,10 +204,9 @@ class FileSystemTreePanel extends JPanel {
 				b.setBorder(BorderFactory.createEmptyBorder());
 				b.setMargin(new Insets(0, 2, 0, 2));
 			} else {
-				final double FACTOR = .25;
 				final Insets insets = b.getMargin();
-				b.setMargin(new Insets(insets.top, (int) (insets.left * FACTOR), insets.bottom,
-						(int) (insets.right * FACTOR)));
+				b.setMargin(new Insets((int) (insets.top * factor), (int) (insets.left * factor),
+						(int) (insets.bottom * factor), (int) (insets.right * factor)));
 			}
 		} catch (final Exception ignored) {
 			// do nothing
@@ -225,7 +219,7 @@ class FileSystemTreePanel extends JPanel {
 	}
 
 	private JButton addDirectoryButton() {
-		final JButton add_directory = thinButton("<HTML>&#43;");
+		final JButton add_directory = thinButton("+", .25f);
 		add_directory.setToolTipText("Add a directory");
 		add_directory.addActionListener(e -> {
 			final String folders = tree.getTopLevelFoldersString();
@@ -257,7 +251,7 @@ class FileSystemTreePanel extends JPanel {
 	}
 
 	private JButton removeDirectoryButton() {
-		final JButton remove_directory = thinButton("<HTML>&#8722;");
+		final JButton remove_directory = thinButton("−", .25f);
 		remove_directory.setToolTipText("Remove a top-level directory");
 		remove_directory.addActionListener(e -> {
 			final TreePath p = tree.getSelectionPath();
@@ -279,7 +273,7 @@ class FileSystemTreePanel extends JPanel {
 	}
 
 	private JButton searchOptionsButton() {
-		final JButton options = thinButton("<HTML>&#8942;");
+		final JButton options = thinButton("⋮", .05f);
 		options.setToolTipText("Filtering options");
 		final JPopupMenu popup = new JPopupMenu();
 		final JCheckBoxMenuItem jcbmi1 = new JCheckBoxMenuItem("Case Sensitive", isCaseSensitive());
@@ -437,7 +431,7 @@ class FileSystemTreePanel extends JPanel {
 		searchField.update();
 	}
 
-	private class SearchField extends JTextField {
+	private class SearchField extends TextEditor.TextFieldWithPlaceholder {
 
 		private static final long serialVersionUID = 7004232238240585434L;
 		private static final String REGEX_HOLDER = "[?*]";
@@ -445,7 +439,6 @@ class FileSystemTreePanel extends JPanel {
 		private static final String DEF_HOLDER = "File filter... ";
 
 		SearchField() {
-			super();
 			try {
 				// make sure pane is large enough to display placeholders
 				final FontMetrics fm = getFontMetrics(getFont());
@@ -453,7 +446,7 @@ class FileSystemTreePanel extends JPanel {
 				final String buf = CASE_HOLDER + REGEX_HOLDER + DEF_HOLDER;
 				final Rectangle2D rect = getFont().getStringBounds(buf, frc);
 				final int prefWidth = (int) rect.getWidth();
-				setColumns(prefWidth / super.getColumnWidth());
+				setColumns(prefWidth / getColumnWidth());
 			} catch (final Exception ignored) {
 				// do nothing
 			}
@@ -464,21 +457,13 @@ class FileSystemTreePanel extends JPanel {
 		}
 
 		@Override
-		protected void paintComponent(final java.awt.Graphics g) {
-			super.paintComponent(g);
-			if (super.getText().isEmpty() && !(FocusManager.getCurrentKeyboardFocusManager().getFocusOwner() == this)) {
-				final Graphics2D g2 = (Graphics2D) g.create();
-				g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-				g2.setColor(Color.GRAY);
-				g2.setFont(getFont().deriveFont(Font.ITALIC));
-				final StringBuilder sb = new StringBuilder(DEF_HOLDER);
-				if (isCaseSensitive())
-					sb.append(CASE_HOLDER);
-				if (isRegexEnabled())
-					sb.append(REGEX_HOLDER);
-				g2.drawString(sb.toString(), 4, g2.getFontMetrics().getHeight());
-				g2.dispose();
-			}
+		String getPlaceholder() {
+			final StringBuilder sb = new StringBuilder(DEF_HOLDER);
+			if (isCaseSensitive())
+				sb.append(CASE_HOLDER);
+			if (isRegexEnabled())
+				sb.append(REGEX_HOLDER);
+			return sb.toString();
 		}
 	}
 }

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
@@ -54,7 +54,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFileChooser;
 import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -119,14 +118,11 @@ class FileSystemTreePanel extends JPanel {
 			final List<File> dirs = Arrays.asList(files).stream().filter(f -> f.isDirectory())
 					.collect(Collectors.toList());
 			if (dirs.isEmpty()) {
-				JOptionPane.showMessageDialog(this, "Only folders can be dropped into the file tree.",
-						"Invalid Drop", JOptionPane.WARNING_MESSAGE);
+				TextEditor.GuiUtils.warn(this, "Only folders can be dropped into the file tree.");
 				return;
 			}
-			final boolean confirm = dirs.size() < 4 || (JOptionPane.showConfirmDialog(this,
-					"Confirm loading of " + dirs.size() + " folders?", "Confirm?",
-					JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION);
-			if (confirm) {
+			if (TextEditor.GuiUtils.confirm(this, "Confirm loading of " + dirs.size() + " folders?", "Confirm?",
+					"Confirm")) {
 				dirs.forEach(dir -> tree.addRootDirectory(dir.getAbsolutePath(), true));
 			}
 		});
@@ -256,8 +252,7 @@ class FileSystemTreePanel extends JPanel {
 		remove_directory.addActionListener(e -> {
 			final TreePath p = tree.getSelectionPath();
 			if (null == p) {
-				JOptionPane.showMessageDialog(this, "Select a top-level folder first.", "Invalid Folder",
-						JOptionPane.ERROR_MESSAGE);
+				TextEditor.GuiUtils.error(this, "Select a top-level folder first.");
 				return;
 			}
 			if (2 == p.getPathCount()) {
@@ -265,8 +260,7 @@ class FileSystemTreePanel extends JPanel {
 				tree.getModel().removeNodeFromParent(//
 						(FileSystemTree.Node) p.getLastPathComponent());
 			} else {
-				JOptionPane.showMessageDialog(this, "Can only remove top-level folders.", "Invalid Folder",
-						JOptionPane.ERROR_MESSAGE);
+				TextEditor.GuiUtils.error(this, "Can only remove top-level folders.");
 			}
 		});
 		return remove_directory;
@@ -326,8 +320,7 @@ class FileSystemTreePanel extends JPanel {
 		jmi.addActionListener(e -> {
 			final TreePath path = tree.getSelectionPath();
 			if (path == null) {
-				JOptionPane.showMessageDialog(this, "No items are currently selected.", "Invalid Selection",
-						JOptionPane.INFORMATION_MESSAGE);
+				TextEditor.GuiUtils.info(this, "No items are currently selected.", "Invalid Selection");
 				return;
 			}
 			try {
@@ -335,8 +328,7 @@ class FileSystemTreePanel extends JPanel {
 				final File f = new File(filepath);
 				Desktop.getDesktop().open((f.isDirectory()) ? f : f.getParentFile());
 			} catch (final Exception | Error ignored) {
-				JOptionPane.showMessageDialog(this, "Folder of selected item does not seem to be accessible.", "Error",
-						JOptionPane.ERROR_MESSAGE);
+				TextEditor.GuiUtils.error(this, "Folder of selected item does not seem to be accessible.");
 			}
 		});
 		popup.add(jmi);
@@ -344,16 +336,14 @@ class FileSystemTreePanel extends JPanel {
 		jmi.addActionListener(e -> {
 			final TreePath path = tree.getSelectionPath();
 			if (path == null) {
-				JOptionPane.showMessageDialog(this, "No items are currently selected.", "Invalid Selection",
-						JOptionPane.INFORMATION_MESSAGE);
+				TextEditor.GuiUtils.info(this,  "No items are currently selected.", "Invalid Selection");
 				return;
 			}
 			try {
 				final String filepath = (String) ((FileSystemTree.Node) path.getLastPathComponent()).getUserObject();
 				TextEditor.GuiUtils.openTerminal(new File(filepath));
 			} catch (final Exception ignored) {
-				JOptionPane.showMessageDialog(this, "Could not open path in Terminal.", "Error",
-						JOptionPane.ERROR_MESSAGE);
+				TextEditor.GuiUtils.error(this, "Could not open path in Terminal.");
 			}
 		});
 		popup.add(jmi);
@@ -381,7 +371,7 @@ class FileSystemTreePanel extends JPanel {
 	}
 
 	private void showHelpMsg() {
-		final String msg = "<HTML><div WIDTH=500>" //
+		final String msg = "<HTML>" //
 				+ "<p><b>Overview</b></p>" //
 				+ "<p>The File Explorer pane provides a direct view of selected folders. Changes in " //
 				+ "the native file system are synchronized in real time.</p>" //
@@ -410,7 +400,7 @@ class FileSystemTreePanel extends JPanel {
 				+ "   <td>Display filenames starting with <i>Demo</i></td>" //
 				+ "  </tr>" //
 				+ "</table>";
-		JOptionPane.showMessageDialog(this, msg, "File Explorer Pane", JOptionPane.PLAIN_MESSAGE);
+		TextEditor.GuiUtils.showHTMLDialog(this.getRootPane(), "File Explorer Pane", msg);
 	}
 
 	private boolean isCaseSensitive() {

--- a/src/main/java/org/scijava/ui/swing/script/FindAndReplaceDialog.java
+++ b/src/main/java/org/scijava/ui/swing/script/FindAndReplaceDialog.java
@@ -151,6 +151,7 @@ public class FindAndReplaceDialog extends JDialog implements ActionListener {
 		return getTextAreaAsEditorPane();
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void show(final boolean replace) {
 		if (replace && restrictToConsole)
@@ -166,7 +167,7 @@ public class FindAndReplaceDialog extends JDialog implements ActionListener {
 		searchField.selectAll();
 		replaceField.selectAll();
 		getRootPane().setDefaultButton(findNext);
-		show();
+		show(); // cannot call setVisible
 	}
 
 	private JTextField createField(final String name, final Container container,

--- a/src/main/java/org/scijava/ui/swing/script/GutterUtils.java
+++ b/src/main/java/org/scijava/ui/swing/script/GutterUtils.java
@@ -49,9 +49,12 @@ public class GutterUtils {
 	GutterUtils(final Gutter gutter) {
 		this.gutter = gutter;
 		gutter.setSpacingBetweenLineNumbersAndFoldIndicator(0);
+		//gutter.setFoldIndicatorStyle(org.fife.ui.rtextarea.FoldIndicatorStyle.MODERN); // DEFAULT
+		gutter.setShowCollapsedRegionToolTips(true);
 	}
 
-	private void updateFoldIcons() {
+	@SuppressWarnings("unused")
+	private void updateFoldIcons() { // no longer needed since v3.3.0
 		int size;
 		try {
 			size = (int) new FoldIndicator(null).getPreferredSize().getWidth();
@@ -63,7 +66,7 @@ public class GutterUtils {
 		final int fontSize = gutter.getLineNumberFont().getSize();
 		if (size > fontSize)
 			size = fontSize;
-		gutter.setFoldIcons(new FoldIcon(true, size), new FoldIcon(false, size));
+		//gutter.setFoldIcons(new FoldIcon(true, size), new FoldIcon(false, size));
 	}
 
 	private ImageIcon getBookmarkIcon() {
@@ -94,10 +97,11 @@ public class GutterUtils {
 
 	public static void updateIcons(final Gutter gutter) {
 		final GutterUtils utils = new GutterUtils(gutter);
-		utils.updateFoldIcons();
+		//utils.updateFoldIcons();
 		utils.updateBookmarkIcon();
 	}
 
+	@SuppressWarnings("unused")
 	private class FoldIcon implements Icon {
 
 		private final boolean collapsed;

--- a/src/main/java/org/scijava/ui/swing/script/Main.java
+++ b/src/main/java/org/scijava/ui/swing/script/Main.java
@@ -38,6 +38,9 @@ import org.scijava.Context;
 import org.scijava.script.ScriptLanguage;
 import org.scijava.script.ScriptService;
 
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+
 /**
  * Main entry point for launching the script editor standalone.
  *
@@ -65,6 +68,7 @@ public final class Main {
 		editor.setVisible(true);
 	}
 	public static void main(String[] args) throws Exception {
+		FlatDarkLaf.setup();
 		String lang = args.length == 0 ? "Java" : args[0];
 		launch(lang);
 	}

--- a/src/main/java/org/scijava/ui/swing/script/OutlineTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/OutlineTreePanel.java
@@ -67,7 +67,7 @@ class OutlineTreePanel extends JScrollPane {
 	private boolean sorted;
 	private boolean major;
 
-	OutlineTreePanel(final TextEditor editor) {
+	OutlineTreePanel() {
 		super();
 		fontSize = getFont().getSize();
 		setViewportView(new UnsupportedLangTree());

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -1789,6 +1789,7 @@ public class TextEditor extends JFrame implements ActionListener,
 				return;
 			}
 			final JRadioButtonMenuItem item = new JRadioButtonMenuItem(k);
+			item.setActionCommand(v); // needed for #updateThemeControls()
 			themeRadioGroup.add(item);
 			item.addActionListener(e -> {
 				try {

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -158,6 +158,7 @@ public class TextEditorTab extends JSplitPane {
 		bc.fill = GridBagConstraints.HORIZONTAL;
 		runit = new JButton("Run");
 		runit.setToolTipText("Control+R, F5, or F11");
+		textEditor.cmdPalette.register(runit, "Interpreter");
 		runit.addActionListener(ae -> textEditor.runText());
 		bottom.add(runit, bc);
 
@@ -175,6 +176,7 @@ public class TextEditorTab extends JSplitPane {
 
 		bc.gridx = 3;
 		incremental = new JCheckBox("REPL");
+		textEditor.cmdPalette.register(incremental, "Interpreter");
 		incremental.setEnabled(true);
 		incremental.setSelected(false);
 		bottom.add(incremental, bc);
@@ -202,7 +204,8 @@ public class TextEditorTab extends JSplitPane {
 			if (showingErrors) editorPane.getErrorHighlighter().reset();
 		});
 		bottom.add(clear, bc);
-		
+		textEditor.cmdPalette.register(clear, "Console");
+
 		bc.gridx = 7;
 		switchSplit = new JButton(RIGHT_ARROW);
 		switchSplit.setToolTipText("Switch location");


### PR DESCRIPTION
Several improvements:

- Implement Command Palette
- Fix a bug in which contextual commands would run twice (e.g., copy and paste)
- Support for Kotlin and Markdown syntaxes
- Reset Layout when reseting preferences
- Patches for RSyntaxArea 3.3.0
- Move all JOptionPane prompts to centralized methods. This simplifies code and would simplify migration to e.g., UIService, or hacking the Swing L&F to match that of the RSyntaxArea theme
