### PR TITLE
Add constructor parameter to specify language preference for REPL

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2009 - 2022, SciJava developers.
+Copyright (c) 2009 - 2023, SciJava developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>script-editor</artifactId>
-	<version>0.7.10-SNAPSHOT</version>
+	<version>0.8.0-SNAPSHOT</version>
 
 	<name>SciJava Script Editor</name>
 	<description>Script Editor and Interpreter for SciJava script languages.</description>

--- a/src/main/java/org/scijava/ui/swing/script/AutoImporter.java
+++ b/src/main/java/org/scijava/ui/swing/script/AutoImporter.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/Bookmark.java
+++ b/src/main/java/org/scijava/ui/swing/script/Bookmark.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/BookmarkDialog.java
+++ b/src/main/java/org/scijava/ui/swing/script/BookmarkDialog.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/CommandPalette.java
+++ b/src/main/java/org/scijava/ui/swing/script/CommandPalette.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/DefaultAutoImporters.java
+++ b/src/main/java/org/scijava/ui/swing/script/DefaultAutoImporters.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/DefaultLanguageSupportService.java
+++ b/src/main/java/org/scijava/ui/swing/script/DefaultLanguageSupportService.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/EditorPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPane.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/EditorPaneActions.java
+++ b/src/main/java/org/scijava/ui/swing/script/EditorPaneActions.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/ErrorHandler.java
+++ b/src/main/java/org/scijava/ui/swing/script/ErrorHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/ErrorParser.java
+++ b/src/main/java/org/scijava/ui/swing/script/ErrorParser.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/ExceptionHandler.java
+++ b/src/main/java/org/scijava/ui/swing/script/ExceptionHandler.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/FileDrop.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileDrop.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/FileFunctions.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileFunctions.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTree.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/FileSystemTreePanel.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/FindAndReplaceDialog.java
+++ b/src/main/java/org/scijava/ui/swing/script/FindAndReplaceDialog.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/GutterUtils.java
+++ b/src/main/java/org/scijava/ui/swing/script/GutterUtils.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/InterpreterPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/InterpreterPane.java
@@ -71,22 +71,32 @@ public class InterpreterPane implements UIComponent<JComponent> {
 	private LogService log;
 
 	/**
-	 * Constructs an interpreter UI pane for a SciJava scripting REPL, with a given language preference.
+	 * Constructs an interpreter UI pane for a SciJava scripting REPL.
 	 *
-	 * @param context The SciJava application context to use
-	 * @param languagePreference The given language to use, or null to fall back to the default.
+	 * @param context The SciJava application context to use.
 	 */
-	public InterpreterPane(final Context context, final String languagePreference) {
+	public InterpreterPane(final Context context) {
+		this(context, null);
+	}
+
+	/**
+	 * Constructs an interpreter UI pane for a SciJava scripting REPL, with a
+	 * given language preference.
+	 *
+	 * @param context The SciJava application context to use.
+	 * @param languagePreference The given language to use, or null to fall back
+	 *          to the default.
+	 */
+	public InterpreterPane(final Context context,
+		final String languagePreference)
+	{
 		context.inject(this);
 		output = new OutputPane(log);
 		final JScrollPane outputScroll = new JScrollPane(output);
 		outputScroll.setPreferredSize(new Dimension(440, 400));
 
-		if(languagePreference == null) {
-			repl = new ScriptREPL(context, output.getOutputStream());
-		} else {
-			repl = new ScriptREPL(context, languagePreference, output.getOutputStream());
-		}
+		repl = new ScriptREPL(context, languagePreference, //
+			output.getOutputStream());
 		repl.initialize();
 
 		final Writer writer = output.getOutputWriter();
@@ -140,10 +150,6 @@ public class InterpreterPane implements UIComponent<JComponent> {
 		mainPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, vars,
 			outputAndPromptPane);
 		mainPane.setDividerLocation(300);
-	}
-
-	public InterpreterPane(final Context context) {
-		this(context, null);
 	}
 
 	// -- InterpreterPane methods --

--- a/src/main/java/org/scijava/ui/swing/script/InterpreterPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/InterpreterPane.java
@@ -71,17 +71,22 @@ public class InterpreterPane implements UIComponent<JComponent> {
 	private LogService log;
 
 	/**
-	 * Constructs an interpreter UI pane for a SciJava scripting REPL.
+	 * Constructs an interpreter UI pane for a SciJava scripting REPL, with a given language preference.
 	 *
 	 * @param context The SciJava application context to use
+	 * @param languagePreference The given language to use, or null to fall back to the default.
 	 */
-	public InterpreterPane(final Context context) {
+	public InterpreterPane(final Context context, final String languagePreference) {
 		context.inject(this);
 		output = new OutputPane(log);
 		final JScrollPane outputScroll = new JScrollPane(output);
 		outputScroll.setPreferredSize(new Dimension(440, 400));
 
-		repl = new ScriptREPL(context, output.getOutputStream());
+		if(languagePreference == null) {
+			repl = new ScriptREPL(context, output.getOutputStream());
+		} else {
+			repl = new ScriptREPL(context, languagePreference, output.getOutputStream());
+		}
 		repl.initialize();
 
 		final Writer writer = output.getOutputWriter();
@@ -135,6 +140,10 @@ public class InterpreterPane implements UIComponent<JComponent> {
 		mainPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, vars,
 			outputAndPromptPane);
 		mainPane.setDividerLocation(300);
+	}
+
+	public InterpreterPane(final Context context) {
+		this(context, null);
 	}
 
 	// -- InterpreterPane methods --

--- a/src/main/java/org/scijava/ui/swing/script/InterpreterPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/InterpreterPane.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
+++ b/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
@@ -60,22 +60,37 @@ public class InterpreterWindow extends JFrame {
 	private LogService log;
 
 	/** Constructs the scripting interpreter window. */
-	public InterpreterWindow(final Context context) {
+	public InterpreterWindow(final Context context, final String languagePreference) {
 		super("Script Interpreter");
 		context.inject(this);
 
-		pane = new InterpreterPane(context) {
-			@Override
-			public void dispose() {
-				super.dispose();
-				InterpreterWindow.super.dispose();
-			}
-		};
+		if(languagePreference == null) {
+			pane = new InterpreterPane(context) {
+				@Override
+				public void dispose() {
+					super.dispose();
+					InterpreterWindow.super.dispose();
+				}
+			};
+		} else {
+			pane = new InterpreterPane(context, languagePreference) {
+				@Override
+				public void dispose() {
+					super.dispose();
+					InterpreterWindow.super.dispose();
+				}
+			};
+		}
 		setContentPane(pane.getComponent());
 
 		pack();
 
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+	}
+
+	/** Construct the scripting interpreter with a given language preference. */
+	public InterpreterWindow(final Context context) {
+		this(context, null);
 	}
 
 	/** Gets the window's associated {@link ScriptREPL}. */

--- a/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
+++ b/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
@@ -59,38 +59,40 @@ public class InterpreterWindow extends JFrame {
 	@Parameter
 	private LogService log;
 
-	/** Constructs the scripting interpreter window. */
-	public InterpreterWindow(final Context context, final String languagePreference) {
+	/**
+	 * Constructs the scripting interpreter window.
+	 *
+	 * @param context The SciJava application context to use.
+	 */
+	public InterpreterWindow(final Context context) {
+		this(context, null);
+	}
+
+	/**
+	 * Constructs the scripting interpreter window.
+	 *
+	 * @param context The SciJava application context to use.
+	 * @param languagePreference The given language to use, or null to fall back
+	 *          to the default.
+	 */
+	public InterpreterWindow(final Context context,
+		final String languagePreference)
+	{
 		super("Script Interpreter");
 		context.inject(this);
 
-		if(languagePreference == null) {
-			pane = new InterpreterPane(context) {
-				@Override
-				public void dispose() {
-					super.dispose();
-					InterpreterWindow.super.dispose();
-				}
-			};
-		} else {
-			pane = new InterpreterPane(context, languagePreference) {
-				@Override
-				public void dispose() {
-					super.dispose();
-					InterpreterWindow.super.dispose();
-				}
-			};
-		}
+		pane = new InterpreterPane(context, languagePreference) {
+			@Override
+			public void dispose() {
+				super.dispose();
+				InterpreterWindow.super.dispose();
+			}
+		};
 		setContentPane(pane.getComponent());
 
 		pack();
 
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-	}
-
-	/** Construct the scripting interpreter with a given language preference. */
-	public InterpreterWindow(final Context context) {
-		this(context, null);
 	}
 
 	/** Gets the window's associated {@link ScriptREPL}. */

--- a/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
+++ b/src/main/java/org/scijava/ui/swing/script/InterpreterWindow.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/JTextAreaOutputStream.java
+++ b/src/main/java/org/scijava/ui/swing/script/JTextAreaOutputStream.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/JTextAreaWriter.java
+++ b/src/main/java/org/scijava/ui/swing/script/JTextAreaWriter.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/LanguageSupportPlugin.java
+++ b/src/main/java/org/scijava/ui/swing/script/LanguageSupportPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/LanguageSupportService.java
+++ b/src/main/java/org/scijava/ui/swing/script/LanguageSupportService.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/MacroFunctions.java
+++ b/src/main/java/org/scijava/ui/swing/script/MacroFunctions.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/Main.java
+++ b/src/main/java/org/scijava/ui/swing/script/Main.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/OutlineTreePanel.java
+++ b/src/main/java/org/scijava/ui/swing/script/OutlineTreePanel.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/OutputPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/OutputPane.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/PromptPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/PromptPane.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/RecentFilesMenuItem.java
+++ b/src/main/java/org/scijava/ui/swing/script/RecentFilesMenuItem.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/ScriptEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/ScriptEditor.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/ScriptInterpreterPlugin.java
+++ b/src/main/java/org/scijava/ui/swing/script/ScriptInterpreterPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/SyntaxHighlighter.java
+++ b/src/main/java/org/scijava/ui/swing/script/SyntaxHighlighter.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditorTab.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/TokenFunctions.java
+++ b/src/main/java/org/scijava/ui/swing/script/TokenFunctions.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/VarsPane.java
+++ b/src/main/java/org/scijava/ui/swing/script/VarsPane.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/autocompletion/ClassUtil.java
+++ b/src/main/java/org/scijava/ui/swing/script/autocompletion/ClassUtil.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/autocompletion/CompletionText.java
+++ b/src/main/java/org/scijava/ui/swing/script/autocompletion/CompletionText.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/autocompletion/ImportCompletion.java
+++ b/src/main/java/org/scijava/ui/swing/script/autocompletion/ImportCompletion.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/autocompletion/ImportCompletionImpl.java
+++ b/src/main/java/org/scijava/ui/swing/script/autocompletion/ImportCompletionImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/autocompletion/ImportFormat.java
+++ b/src/main/java/org/scijava/ui/swing/script/autocompletion/ImportFormat.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/commands/ChooseFontSize.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/ChooseFontSize.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/commands/ChooseTabSize.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/ChooseTabSize.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/commands/GitGrep.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/GitGrep.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/commands/KillScript.java
+++ b/src/main/java/org/scijava/ui/swing/script/commands/KillScript.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/highliters/BeanshellHighlighter.java
+++ b/src/main/java/org/scijava/ui/swing/script/highliters/BeanshellHighlighter.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/highliters/ECMAScriptHighlighter.java
+++ b/src/main/java/org/scijava/ui/swing/script/highliters/ECMAScriptHighlighter.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/highliters/IJ1MacroHighlighter.java
+++ b/src/main/java/org/scijava/ui/swing/script/highliters/IJ1MacroHighlighter.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/highliters/ImageJMacroTokenMaker.java
+++ b/src/main/java/org/scijava/ui/swing/script/highliters/ImageJMacroTokenMaker.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/highliters/MatlabHighlighter.java
+++ b/src/main/java/org/scijava/ui/swing/script/highliters/MatlabHighlighter.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/highliters/MatlabTokenMaker.java
+++ b/src/main/java/org/scijava/ui/swing/script/highliters/MatlabTokenMaker.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
+++ b/src/main/java/org/scijava/ui/swing/script/languagesupport/JavaLanguageSupportPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
+++ b/src/main/java/org/scijava/ui/swing/script/languagesupport/JavaScriptLanguageSupportPlugin.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/main/java/org/scijava/ui/swing/script/search/ScriptSourceSearchActionFactory.java
+++ b/src/main/java/org/scijava/ui/swing/script/search/ScriptSourceSearchActionFactory.java
@@ -2,17 +2,17 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/test/java/org/scijava/script/parse/ParsingtonBindings.java
+++ b/src/test/java/org/scijava/script/parse/ParsingtonBindings.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/org/scijava/script/parse/ParsingtonScriptEngine.java
+++ b/src/test/java/org/scijava/script/parse/ParsingtonScriptEngine.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/org/scijava/script/parse/ParsingtonScriptLanguage.java
+++ b/src/test/java/org/scijava/script/parse/ParsingtonScriptLanguage.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/org/scijava/script/search/ScriptSourceSearchActionFactoryTest.java
+++ b/src/test/java/org/scijava/script/search/ScriptSourceSearchActionFactoryTest.java
@@ -2,17 +2,17 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/test/java/org/scijava/ui/swing/script/ScriptEditorTestDrive.java
+++ b/src/test/java/org/scijava/ui/swing/script/ScriptEditorTestDrive.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/src/test/java/org/scijava/ui/swing/script/ScriptInterpreterTestDrive.java
+++ b/src/test/java/org/scijava/ui/swing/script/ScriptInterpreterTestDrive.java
@@ -2,7 +2,7 @@
  * #%L
  * Script Editor and Interpreter for SciJava script languages.
  * %%
- * Copyright (C) 2009 - 2022 SciJava developers.
+ * Copyright (C) 2009 - 2023 SciJava developers.
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This PR adds constructor parameters to InterpreterPane and InterpreterWindow, such that a startup language can be handed over the ScriptREPL instance. This prevents the need to initialise the wrong language first, and then only the one you actually need. 