### PR TITLE
make OpenAI API key optional and prompt prefix, model name configurable

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/OpenAIOptions.java
+++ b/src/main/java/org/scijava/ui/swing/script/OpenAIOptions.java
@@ -41,8 +41,18 @@ import org.scijava.plugin.Plugin;
 @Plugin(type = OptionsPlugin.class, menuPath = "Edit>Options>OpenAI...")
 public class OpenAIOptions extends OptionsPlugin {
 
-	@Parameter(label = "OpenAI key")
+	@Parameter(label = "OpenAI key", required = false)
 	private String openAIKey;
+
+	@Parameter(label = "OpenAI Model name")
+	private String modelName = "gpt-3.5-turbo-0613";
+
+	@Parameter(label = "Prompt prefix (added before custom prompt)", style = "text area")
+	private String promptPrefix = "Write code in {programming_language}.\n" +
+			"Write concise and high quality code for ImageJ/Fiji.\n" +
+			"Put minimal comments explaining what the code does.\n" +
+			"The code should do the following:\n" +
+			"{custom_prompt}";
 
 	public String getOpenAIKey() {
 		return openAIKey;
@@ -51,4 +61,22 @@ public class OpenAIOptions extends OptionsPlugin {
 	public void setOpenAIKey(final String openAIKey) {
 		this.openAIKey = openAIKey;
 	}
+
+	public String getPromptPrefix() {
+		return promptPrefix;
+	}
+
+	public void setPromptPrefix(final String promptPrefix) {
+		this.promptPrefix = promptPrefix;
+	}
+
+	public String getModelName() {
+		return modelName;
+	}
+
+	public void setModelName(final String modelName) {
+		this.modelName = modelName;
+	}
+
+
 }

--- a/src/main/java/org/scijava/ui/swing/script/TextEditor.java
+++ b/src/main/java/org/scijava/ui/swing/script/TextEditor.java
@@ -3250,11 +3250,9 @@ public class TextEditor extends JFrame implements ActionListener,
 
 			// setup default prompt
 			String prompt =
-					"Write code in " + getCurrentLanguage().getLanguageName() + ".\n" +
-					"Write concise and high quality code for ImageJ/Fiji.\n" +
-					"Put minimal comments explaining what the code does.\n" +
-					"The code should do the following:\n" +
-					getTextArea().getSelectedText();
+					promptPrefix()
+							.replace("{programming_language}",  getCurrentLanguage().getLanguageName() )
+							.replace("{custom_prompt}", getTextArea().getSelectedText());
 
 			String answer = askChatGPT(prompt);
 
@@ -3289,7 +3287,7 @@ public class TextEditor extends JFrame implements ActionListener,
 
 		ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest
 				.builder()
-				.model("gpt-3.5-turbo-0613")
+				.model(modelName())
 				.messages(messages).build();
 
 		ChatMessage responseMessage = service.createChatCompletion(chatCompletionRequest).getChoices().get(0).getMessage();
@@ -3311,6 +3309,31 @@ public class TextEditor extends JFrame implements ActionListener,
 		}
 		return System.getenv("OPENAI_API_KEY");
 	}
+
+	private String modelName() {
+		if (optionsService != null) {
+			final OpenAIOptions openAIOptions =
+					optionsService.getOptions(OpenAIOptions.class);
+			if (openAIOptions != null) {
+				final String key = openAIOptions.getModelName();
+				if (key != null && !key.isEmpty()) return key;
+			}
+		}
+		return null;
+	}
+
+	private String promptPrefix() {
+		if (optionsService != null) {
+			final OpenAIOptions openAIOptions =
+					optionsService.getOptions(OpenAIOptions.class);
+			if (openAIOptions != null) {
+				final String promptPrefix = openAIOptions.getPromptPrefix();
+				if (promptPrefix != null && !promptPrefix.isEmpty()) return promptPrefix;
+			}
+		}
+		return "";
+	}
+
 
 	public void extractSourceJar(final File file) {
 		try {


### PR DESCRIPTION
Hi @ctrueden ,

this is a small follow-up PR to #67 . I was modifying the OpenAI Options dialog:
* The API Key is optional now (as it could be configured via the OS environemnt)
* The prompt prefix can be customized, enabling people to play with this
* The model name can be chosen now, e.g. I think it makes sense to try out gpt-4-turbo

The window is a bit small though...
![image](https://github.com/scijava/script-editor/assets/12660498/baa68a6b-46fd-4b68-b20d-f1a4edbb0a58)

If you know how to make it wider (e.g. like this), I'd be happy to fix this before merging.
![image](https://github.com/scijava/script-editor/assets/12660498/f958db5e-0393-40f4-b30d-c57fba34ea7a)

Let me know what you think!

Best,
Robert