### PR TITLE
Patch ImageJMacroTokenMaker to accommodate RSyntaxtTextArea v3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>37.0.0</version>
+		<version>40.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -147,6 +147,8 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
+
+		<rsyntaxtextarea.version>3.6.0</rsyntaxtextarea.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/scijava/ui/swing/script/highliters/ImageJMacroTokenMaker.java
+++ b/src/main/java/org/scijava/ui/swing/script/highliters/ImageJMacroTokenMaker.java
@@ -2635,6 +2635,11 @@ public class ImageJMacroTokenMaker extends AbstractJFlexCTokenMaker {
 		zzMarkedPos -= number;
 	}
 
+	@Override
+	public int yystate() {
+		return zzLexicalState; // the current lexical state
+	}
+
 	/**
 	 * Resumes scanning until the next regular expression is matched, the end of
 	 * input is encountered or an I/O-Error occurs.


### PR DESCRIPTION
This fixes the issue detailed in https://github.com/scijava/pom-scijava/pull/288

Context:
In newer versions of RSyntaxtTextArea, AbstractJFlexCTokenMaker adds an abstract yystate() method intended to return the current state of a JFlex lexer. Since it is abstract, it must be implemented by any concrete subclass, so we patch ImageJMacroTokenMaker so that the current zzLexicalState is returned

Tested with: `mvn clean package -Denforcer.skip`